### PR TITLE
Fix to work when clock_gettime or CLOCK_REALTIME are not present

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,23 +8,16 @@ on:
 
 jobs:
   tests:
-    name: Python ${{ matrix.python-version }} (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-18.04
 
     strategy:
-      fail-fast: false
       matrix:
         python-version:
         - 3.6
         - 3.7
         - 3.8
         - 3.9
-        os: 
-        - ubuntu-18.04
-        - macos-10.15
-        exclude:
-          - os: macos-10.15
-            python-version: 3.9
 
     env:
       COVERALLS_REPO_TOKEN: htkNb8R1RkwGsTnH2VDIiuPsFDW4rXVpP

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,16 +8,23 @@ on:
 
 jobs:
   tests:
-    name: Python ${{ matrix.python-version }}
-    runs-on: ubuntu-18.04
+    name: Python ${{ matrix.python-version }} (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         python-version:
         - 3.6
         - 3.7
         - 3.8
         - 3.9
+        os: 
+        - ubuntu-18.04
+        - macos-10.15
+        exclude:
+          - os: macos-10.15
+            python-version: 3.9
 
     env:
       COVERALLS_REPO_TOKEN: htkNb8R1RkwGsTnH2VDIiuPsFDW4rXVpP

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@ History
 
 * Add ``shift()`` method to move forward in time by a delta whilst travelling.
   This is based on freezegun's ``tick()`` method.
+* Fix to work when either ``clock_gettime()`` or ``CLOCK_REALTIME`` is not
+  present. This happens on some Unix platforms, for example on macOS with the
+  official Python.org installer, which is compiled against macOS 10.9.
+
+  Thanks to Daniel Crowe for the fix in
+  `PR #30 <https://github.com/adamchainz/time-machine/pull/30>`__.
 
 1.0.1 (2020-05-29)
 ------------------

--- a/src/_time_machine.c
+++ b/src/_time_machine.c
@@ -121,6 +121,10 @@ Call datetime.datetime.utcnow() after patching.");
 
 /* time.clock_gettime() */
 
+/*
+    time.clock_gettime() is not always available
+    e.g. on builds against old macOS = official Python.org installer
+*/
 #if defined(HAVE_CLOCK_GETTIME)
 
 static PyObject*

--- a/src/_time_machine.c
+++ b/src/_time_machine.c
@@ -121,6 +121,8 @@ Call datetime.datetime.utcnow() after patching.");
 
 /* time.clock_gettime() */
 
+#if defined(HAVE_CLOCK_GETTIME)
+
 static PyObject*
 _time_machine_clock_gettime(PyObject *self, PyObject *args)
 {
@@ -176,6 +178,7 @@ PyDoc_STRVAR(original_clock_gettime_ns_doc,
 \n\
 Call time.clock_gettime_ns() after patching.");
 
+#endif
 #endif
 
 /* time.gmtime() */
@@ -349,6 +352,7 @@ _time_machine_patch_if_needed(PyObject *self, PyObject *unused)
 
     PyObject *time_module = PyImport_ImportModule("time");
 
+#if defined(HAVE_CLOCK_GETTIME)
     PyCFunctionObject *time_clock_gettime = (PyCFunctionObject *) PyObject_GetAttrString(time_module, "clock_gettime");
     original_clock_gettime = time_clock_gettime->m_ml->ml_meth;
     time_clock_gettime->m_ml->ml_meth = _time_machine_clock_gettime;
@@ -359,6 +363,8 @@ _time_machine_patch_if_needed(PyObject *self, PyObject *unused)
     original_clock_gettime_ns = time_clock_gettime_ns->m_ml->ml_meth;
     time_clock_gettime_ns->m_ml->ml_meth = _time_machine_clock_gettime_ns;
     Py_DECREF(time_clock_gettime_ns);
+#endif
+
 #endif
 
     PyCFunctionObject *time_gmtime = (PyCFunctionObject *) PyObject_GetAttrString(time_module, "gmtime");
@@ -408,9 +414,11 @@ static PyMethodDef module_methods[] = {
     {"original_now", (PyCFunction)_time_machine_original_now, METH_FASTCALL, original_now_doc},
 #endif
     {"original_utcnow", (PyCFunction)_time_machine_original_utcnow, METH_NOARGS, original_utcnow_doc},
+#if defined(HAVE_CLOCK_GETTIME)
     {"original_clock_gettime", (PyCFunction)_time_machine_original_clock_gettime, METH_VARARGS, original_clock_gettime_doc},
 #if PY_VERSION_HEX >= 0x03070000
     {"original_clock_gettime_ns", (PyCFunction)_time_machine_original_clock_gettime_ns, METH_VARARGS, original_clock_gettime_ns_doc},
+#endif
 #endif
     {"original_gmtime", (PyCFunction)_time_machine_original_gmtime, METH_VARARGS, original_gmtime_doc},
     {"original_localtime", (PyCFunction)_time_machine_original_localtime, METH_VARARGS, original_localtime_doc},

--- a/src/time_machine.py
+++ b/src/time_machine.py
@@ -14,7 +14,7 @@ import _time_machine
 # e.g. on builds against old macOS = official Python.org installer
 try:
     from time import CLOCK_REALTIME
-except ImportError:
+except ImportError:  # pragma: no cover
     # Dummy value that won't compare equal to any value
     CLOCK_REALTIME = float("inf")
 

--- a/src/time_machine.py
+++ b/src/time_machine.py
@@ -14,7 +14,7 @@ import _time_machine
 # e.g. on builds against old macOS = official Python.org installer
 try:
     from time import CLOCK_REALTIME
-except ImportError:  # pragma: no cover
+except ImportError:
     # Dummy value that won't compare equal to any value
     CLOCK_REALTIME = float("inf")
 

--- a/src/time_machine.py
+++ b/src/time_machine.py
@@ -16,7 +16,7 @@ try:
     from time import CLOCK_REALTIME
 except ImportError:
     # Dummy value that won't compare equal to any value
-    CLOCK_REALTIME = float('inf')
+    CLOCK_REALTIME = float("inf")
 
 NANOSECONDS_PER_SECOND = 1_000_000_000
 
@@ -202,6 +202,7 @@ def utcnow():
 
 
 # time module
+
 
 def clock_gettime(clk_id):
     if not coordinates_stack or clk_id != CLOCK_REALTIME:

--- a/src/time_machine.py
+++ b/src/time_machine.py
@@ -2,8 +2,8 @@ import datetime as dt
 import functools
 import inspect
 import sys
+import time
 import uuid
-from time import CLOCK_REALTIME
 from types import GeneratorType
 from unittest import TestCase, mock
 
@@ -12,6 +12,8 @@ from dateutil.parser import parse as parse_datetime
 import _time_machine
 
 NANOSECONDS_PER_SECOND = 1_000_000_000
+
+_HAVE_CLOCK_GETTIME = hasattr(time, "clock_gettime")
 
 
 class Coordinates:
@@ -196,19 +198,20 @@ def utcnow():
 
 # time module
 
+if _HAVE_CLOCK_GETTIME:
+    CLOCK_REALTIME = time.CLOCK_REALTIME
 
-def clock_gettime(clk_id):
-    if not coordinates_stack or clk_id != CLOCK_REALTIME:
-        return _time_machine.original_clock_gettime(clk_id)
-    return time()
-
-
-if sys.version_info >= (3, 7):
-
-    def clock_gettime_ns(clk_id):
+    def clock_gettime(clk_id):
         if not coordinates_stack or clk_id != CLOCK_REALTIME:
-            return _time_machine.original_clock_gettime_ns(clk_id)
-        return time_ns()
+            return _time_machine.original_clock_gettime(clk_id)
+        return time()
+
+    if sys.version_info >= (3, 7):
+
+        def clock_gettime_ns(clk_id):
+            if not coordinates_stack or clk_id != CLOCK_REALTIME:
+                return _time_machine.original_clock_gettime_ns(clk_id)
+            return time_ns()
 
 
 def gmtime(secs=None):

--- a/src/time_machine.py
+++ b/src/time_machine.py
@@ -204,7 +204,7 @@ def utcnow():
 # time module
 
 def clock_gettime(clk_id):
-    if not coordinates_stack or clk_id != time.CLOCK_REALTIME:
+    if not coordinates_stack or clk_id != CLOCK_REALTIME:
         return _time_machine.original_clock_gettime(clk_id)
     return time()
 
@@ -212,7 +212,7 @@ def clock_gettime(clk_id):
 if sys.version_info >= (3, 7):
 
     def clock_gettime_ns(clk_id):
-        if not coordinates_stack or clk_id != time.CLOCK_REALTIME:
+        if not coordinates_stack or clk_id != CLOCK_REALTIME:
             return _time_machine.original_clock_gettime_ns(clk_id)
         return time_ns()
 

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -19,6 +19,9 @@ LIBRARY_EPOCH_DATETIME = dt.datetime(2020, 4, 29)  # The day this library was ma
 LIBRARY_EPOCH = LIBRARY_EPOCH_DATETIME.timestamp()
 
 py_3_7_plus = pytest.mark.skipif(sys.version_info < (3, 7), reason="Python 3.7+")
+py_have_clock_gettime = pytest.mark.skipif(
+    not hasattr(time, "clock_gettime"), reason="Doesn't have clock_gettime"
+)
 
 
 # datetime module
@@ -85,12 +88,14 @@ def test_date_today():
 # time module
 
 
+@py_have_clock_gettime
 def test_time_clock_gettime_realtime():
     with time_machine.travel(EPOCH + 180.0):
         assert time.clock_gettime(time.CLOCK_REALTIME) == EPOCH + 180.0
     assert time.clock_gettime(time.CLOCK_REALTIME) >= LIBRARY_EPOCH
 
 
+@py_have_clock_gettime
 def test_time_clock_gettime_monotonic_unaffected():
     start = time.clock_gettime(time.CLOCK_MONOTONIC)
     with time_machine.travel(EPOCH + 180.0):
@@ -100,6 +105,7 @@ def test_time_clock_gettime_monotonic_unaffected():
 
 
 @py_3_7_plus
+@py_have_clock_gettime
 def test_time_clock_gettime_ns_realtime():
     with time_machine.travel(EPOCH + 190.0):
         first = time.clock_gettime_ns(time.CLOCK_REALTIME)
@@ -112,6 +118,7 @@ def test_time_clock_gettime_ns_realtime():
 
 
 @py_3_7_plus
+@py_have_clock_gettime
 def test_time_clock_gettime_ns_monotonic_unaffected():
     start = time.clock_gettime_ns(time.CLOCK_MONOTONIC)
     with time_machine.travel(EPOCH + 190.0):

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -25,13 +25,22 @@ py_have_clock_gettime = pytest.mark.skipif(
 )
 
 
+@pytest.mark.skipif(
+    not hasattr(time, "CLOCK_REALTIME"), reason="No time.CLOCK_REALTIME"
+)
 def test_import_without_clock_realtime():
-    # Recipe for importing from path as documented in importlib
-    spec = spec_from_file_location(
-        f"{__name__}.time_machine_without_clock_realtime", time_machine.__file__
-    )
-    module = module_from_spec(spec)
-    spec.loader.exec_module(module)
+    orig = time.CLOCK_REALTIME
+    del time.CLOCK_REALTIME
+    try:
+        # Recipe for importing from path as documented in importlib
+        spec = spec_from_file_location(
+            f"{__name__}.time_machine_without_clock_realtime", time_machine.__file__
+        )
+        module = module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+    finally:
+        time.CLOCK_REALTIME = orig
 
     # No assertions - testing for coverage only
 

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -3,6 +3,7 @@ import datetime as dt
 import sys
 import time
 import uuid
+from importlib.util import module_from_spec, spec_from_file_location
 from unittest import SkipTest, TestCase
 
 import pytest
@@ -22,6 +23,17 @@ py_3_7_plus = pytest.mark.skipif(sys.version_info < (3, 7), reason="Python 3.7+"
 py_have_clock_gettime = pytest.mark.skipif(
     not hasattr(time, "clock_gettime"), reason="Doesn't have clock_gettime"
 )
+
+
+def test_import_without_clock_realtime():
+    # Recipe for importing from path as documented in importlib
+    spec = spec_from_file_location(
+        f"{__name__}.time_machine_without_clock_realtime", time_machine.__file__
+    )
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    # No assertions - testing for coverage only
 
 
 # datetime module


### PR DESCRIPTION
Python in macos has a couple of challenges to be overcome:

CLOCK_REALTIME and clock_gettime are not present. The python docs list it as available in Unix environments, but this doesn't seem to include macos:
https://docs.python.org/3/library/time.html#time.CLOCK_REALTIME
https://news.ycombinator.com/item?id=6303755
