### PR TITLE
Move C-level clock_gettime() and clock_gettime_ns() checks to runtime

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,9 @@
 History
 =======
 
+* Move C-level ``clock_gettime()`` and ``clock_gettime_ns()`` checks to
+  runtime to allow distribution of macOS wheels.
+
 1.1.0 (2020-06-08)
 ------------------
 


### PR DESCRIPTION
Fixes #36.

Tested by building wheel locally with pyenv Python and installing and using it on Python.org Python.