### PR TITLE
Return naive datetimes from mocked datetime.utcnow()

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 History
 =======
 
+* Correctly return naive datetimes from ``datetime.utcnow()`` whilst time
+  travelling.
+
+  Thanks to Søren Pilgård and Bart Van Loon for the report in
+  `Issue #52 <https://github.com/adamchainz/time-machine/issues/52>`__.
+
 1.2.0 (2020-07-08)
 ------------------
 

--- a/src/time_machine.py
+++ b/src/time_machine.py
@@ -206,7 +206,7 @@ def utcnow():
     if not coordinates_stack:
         return _time_machine.original_utcnow()
     else:
-        return dt.datetime.fromtimestamp(time(), dt.timezone.utc)
+        return dt.datetime.utcfromtimestamp(time())
 
 
 # time module

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -88,6 +88,7 @@ def test_datetime_utcnow():
         assert now.minute == 0
         assert now.second == 0
         assert now.microsecond == 0
+        assert now.tzinfo is None
     assert dt.datetime.utcnow() >= LIBRARY_EPOCH_DATETIME
 
 


### PR DESCRIPTION
Fixes #52.