### PR TITLE
using tz_offset only for local time

### DIFF
--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -405,12 +405,24 @@ class UnitTestClassSetUpClassSkipTests(TestCase):
 
 def test_tz_offset_float():
     with time_machine.travel(EPOCH, tz_offset=3600.0):
-        assert time.time() == EPOCH + 3600.0
+        assert time.time() == EPOCH
+
+    with time_machine.travel(EPOCH, tz_offset=3600.0):
+        assert dt.datetime.utcnow() == dt.datetime(1970, 1, 1, 0, 0, 0)
+
+    with time_machine.travel(EPOCH, tz_offset=3600.0):
+        assert dt.datetime.now() == dt.datetime(1970, 1, 1, 1, 0, 0)
 
 
 def test_tz_offset_timedelta():
     with time_machine.travel(EPOCH, tz_offset=dt.timedelta(hours=5.5)):
-        assert time.time() == EPOCH + (5.5 * 3600.0)
+        assert time.time() == EPOCH
+
+    with time_machine.travel(EPOCH, tz_offset=dt.timedelta(hours=5.5)):
+        assert dt.datetime.utcnow() == dt.datetime(1970, 1, 1, 0, 0, 0)
+
+    with time_machine.travel(EPOCH, tz_offset=dt.timedelta(hours=5.5)):
+        assert dt.datetime.now() == dt.datetime(1970, 1, 1, 5, 30, 0)
 
 
 def test_tz_offset_unsupported_type():


### PR DESCRIPTION
Hi,

want to migrate from libfaketime to time-machine.

But unlike in libfaketime and freezegun, tz_offset is used also for the UTC time. In freezegun and libfaketime tz_offset is used only to determine the "local" time.

see the following tests:
https://github.com/simon-weber/python-libfaketime/blob/master/test/test_faketime.py#L53
https://github.com/spulec/freezegun/blob/master/tests/test_datetimes.py#L77

This PR tries to fix that, but it isn't complete. The local time somehow has an offset of 1 hour. But I create it to maybe give a starting point to fix this.

