### PR TITLE
Mock timezone when destination has a ZoneInfo timezone

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,8 @@ History
 * After a call to ``move_to()``, the first function call to retrieve the
   current time will return exactly the destination time, copying the behaviour
   of the first call to ``travel()``.
+* Remove ``tz_offset`` argument. This was incorrectly copied from
+  ``freezegun``.
 
 1.3.0 (2020-12-12)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,8 +7,9 @@ History
 * After a call to ``move_to()``, the first function call to retrieve the
   current time will return exactly the destination time, copying the behaviour
   of the first call to ``travel()``.
+* Added the ``timezone`` argument. This can mock the current timezone on Unix.
 * Remove ``tz_offset`` argument. This was incorrectly copied from
-  ``freezegun``.
+  ``freezegun``. Use the new ``timezone`` argument instead.
 
 1.3.0 (2020-12-12)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,9 +7,9 @@ History
 * After a call to ``move_to()``, the first function call to retrieve the
   current time will return exactly the destination time, copying the behaviour
   of the first call to ``travel()``.
-* Added the ``timezone`` argument. This can mock the current timezone on Unix.
+* Add the ability to shift timezone by passing in a ``ZoneInfo`` timezone.
 * Remove ``tz_offset`` argument. This was incorrectly copied from
-  ``freezegun``. Use the new ``timezone`` argument instead.
+  ``freezegun``. Use the new timezone mocking with ``ZoneInfo`` instead.
 
 1.3.0 (2020-12-12)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -329,7 +329,7 @@ Migrating from libfaketime or freezegun
 =======================================
 
 freezegun has a useful API, and python-libfaketime copies some of it, with a different function name.
-time-machine also copies some of freezegun's API, in ``travel()``\'s ``destination``, ``tick``, and ``tz_offset`` arguments, and the ``shift()`` method.
+time-machine also copies some of freezegun's API, in ``travel()``\'s ``destination``, and ``tick`` arguments, and the ``shift()`` method.
 There are a few differences:
 
 * time-machine's ``tick`` argument defaults to ``True``, because code tends to make the (reasonable) assumption that time progresses between function calls, and should normally be tested as such.

--- a/README.rst
+++ b/README.rst
@@ -83,13 +83,9 @@ If ``True``, the default, successive calls to mocked functions return values inc
 So after starting travel to ``0.0`` (the UNIX epoch), the first call to any datetime function will return its representation of ``1970-01-01 00:00:00.000000`` exactly.
 The following calls "tick," so if a call was made exactly half a second later, it would return ``1970-01-01 00:00:00.500000``.
 
-``timezone`` specifies the timezone to change to.
-This works on `Unix only <https://docs.python.org/3/library/intro.html#availability>`__.
-It may be:
-
-* A string in the format as described in `the time.tzset documentation <https://docs.python.org/3/library/time.html#time.tzset>`__.
-* A number of hours.
-* A ``timedelta``.
+``timezone`` specifies the timezone to change to, via ``time.tzset()`` (only available on Unix).
+This should be a string in one of the formats described in `the time.tzset documentation <https://docs.python.org/3/library/time.html#time.tzset>`__
+It’s normally most convenient to use a timezone name, such as ``'Africa/Addis_Ababa'``.
 
 Mocked Functions
 ^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -56,8 +56,8 @@ I created time-machine whilst writing the book.
 Usage
 =====
 
-``travel(destination, *, tick=True, tz_offset=None)``
------------------------------------------------------
+``travel(destination, *, tick=True, timezone=None)``
+----------------------------------------------------
 
 ``travel()`` is a class that allows time travel, to the datetime specified by ``destination``.
 It does so by mocking all functions from Python's standard library that return the current date or datetime.
@@ -83,9 +83,13 @@ If ``True``, the default, successive calls to mocked functions return values inc
 So after starting travel to ``0.0`` (the UNIX epoch), the first call to any datetime function will return its representation of ``1970-01-01 00:00:00.000000`` exactly.
 The following calls "tick," so if a call was made exactly half a second later, it would return ``1970-01-01 00:00:00.500000``.
 
-``tz_offset`` allows you to offset the given destination.
-It may be a ``timedelta`` or a number of seconds, which will be added to destination.
-It may be negative.
+``timezone`` specifies the timezone to change to.
+This works on `Unix only <https://docs.python.org/3/library/intro.html#availability>`__.
+It may be:
+
+* A string in the format as described in `the time.tzset documentation <https://docs.python.org/3/library/time.html#time.tzset>`__.
+* A number of hours.
+* A ``timedelta``.
 
 Mocked Functions
 ^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -25,9 +25,12 @@ A quick example:
 .. code-block:: python
 
     import datetime as dt
+    from zoneinfo import ZoneInfo
     import time_machine
 
-    @time_machine.travel("1985-10-26 01:24")
+    hill_valley_tz = ZoneInfo("America/Los_Angeles")
+
+    @time_machine.travel(dt.datetime(1985, 10, 26, 1, 24, tzinfo=hill_valley_tz))
     def test_delorean():
         assert dt.date.today().isoformat() == "1985-10-26"
 
@@ -56,8 +59,8 @@ I created time-machine whilst writing the book.
 Usage
 =====
 
-``travel(destination, *, tick=True, timezone=None)``
-----------------------------------------------------
+``travel(destination, *, tick=True)``
+-------------------------------------
 
 ``travel()`` is a class that allows time travel, to the datetime specified by ``destination``.
 It does so by mocking all functions from Python's standard library that return the current date or datetime.
@@ -68,10 +71,14 @@ It may be:
 
 * A ``datetime.datetime``.
   If it is naive, it will be assumed to have the UTC timezone.
+  If it has ``tzinfo`` set to a |zoneinfo-instance|_, the current timezone will also be mocked.
 * A ``datetime.date``.
   This will be converted to a UTC datetime with the time 00:00:00.
 * A ``float`` or ``int`` specifying a `Unix timestamp <https://en.m.wikipedia.org/wiki/Unix_time>`__
 * A string, which will be parsed with `dateutil.parse <https://dateutil.readthedocs.io/en/stable/parser.html>`__ and converted to a timestamp.
+
+.. |zoneinfo-instance| replace:: ``zoneinfo.ZoneInfo`` instance
+.. _zoneinfo-instance: https://docs.python.org/3/library/zoneinfo.html#zoneinfo.ZoneInfo
 
 Additionally, you can provide some more complex types:
 
@@ -82,10 +89,6 @@ Additionally, you can provide some more complex types:
 If ``True``, the default, successive calls to mocked functions return values increasing by the elapsed real time *since the first call.*
 So after starting travel to ``0.0`` (the UNIX epoch), the first call to any datetime function will return its representation of ``1970-01-01 00:00:00.000000`` exactly.
 The following calls "tick," so if a call was made exactly half a second later, it would return ``1970-01-01 00:00:00.500000``.
-
-``timezone`` specifies the timezone to change to, via ``time.tzset()`` (only available on Unix).
-This should be a string in one of the formats described in `the time.tzset documentation <https://docs.python.org/3/library/time.html#time.tzset>`__
-It’s normally most convenient to use a timezone name, such as ``'Africa/Addis_Ababa'``.
 
 Mocked Functions
 ^^^^^^^^^^^^^^^^
@@ -186,6 +189,40 @@ When applied as a class decorator to such classes, time is mocked from the start
             assert 0.0 < time.time() < 1.0
 
 Note this is different to ``unittest.mock.patch()``\'s behaviour, which is to mock only during the test methods.
+
+Timezone mocking
+^^^^^^^^^^^^^^^^
+
+If the ``destination`` passed to ``time_machine.travel()`` or ``Coordinates.move_to()`` has its ``tzinfo`` set to a |zoneinfo-instance2|_, the current timezone will be mocked.
+This will be done by calling |time-tzset|_ (only available on Unix) and thus affects the ``time`` module’s `timezone constants <https://docs.python.org/3/library/time.html#timezone-constants>`__ and features that rely on those, such as ``time.localtime()``.
+
+.. |zoneinfo-instance2| replace:: ``zoneinfo.ZoneInfo`` instance
+.. _zoneinfo-instance2: https://docs.python.org/3/library/zoneinfo.html#zoneinfo.ZoneInfo
+
+.. |time-tzset| replace:: ``time.tzset()``
+.. _time-tzset: https://docs.python.org/3/library/time.html#time.tzset
+
+time-machine won’t affect other concepts of “the current timezone”, such as Django’s (which can be changed with its |timezone-override|_).
+
+.. |timezone-override| replace:: ``time.override()``
+.. _timezone-override: https://docs.djangoproject.com/en/stable/ref/utils/#django.utils.timezone.override
+
+Here’s a worked example changing the current timezone:
+
+.. code-block:: python
+
+    import datetime as dt
+    import time
+    from zoneinfo import ZoneInfo
+    import time_machine
+
+    hill_valley_tz = ZoneInfo("America/Los_Angeles")
+
+    @time_machine.travel(dt.datetime(2015, 10, 21, 16, 29, tzinfo=hill_valley_tz))
+    def test_hoverboard_era():
+        assert time.tzname == ("PST", "PDT")
+        now = dt.datetime.now()
+        assert (now.hour, now.minute) == (16, 29)
 
 ``Coordinates``
 ---------------
@@ -332,6 +369,9 @@ There are a few differences:
   Testing with time frozen can make it easy to write complete assertions, but it's quite artificial.
 * freezegun's ``tick()`` method has been implemented as ``shift()``, to avoid confusion with the ``tick`` argument.
   It also requires an explicit delta rather than defaulting to 1 second.
+* freezegun's ``tz_offset`` argument only partially mocks the current time zone.
+  Time zones are more complicated than a single offset from UTC, and freezegun only uses the offset in ``time.localtime()``.
+  Instead, time-machine will mock the current time zone if you give it a ``datetime`` with a ``ZoneInfo`` timezone.
 
 Some features aren't supported like the ``auto_tick_seconds`` argument.
 These may be added in a future release.

--- a/README.rst
+++ b/README.rst
@@ -194,7 +194,8 @@ Timezone mocking
 ^^^^^^^^^^^^^^^^
 
 If the ``destination`` passed to ``time_machine.travel()`` or ``Coordinates.move_to()`` has its ``tzinfo`` set to a |zoneinfo-instance2|_, the current timezone will be mocked.
-This will be done by calling |time-tzset|_ (only available on Unix) and thus affects the ``time`` module’s `timezone constants <https://docs.python.org/3/library/time.html#timezone-constants>`__ and features that rely on those, such as ``time.localtime()``.
+This will be done by calling |time-tzset|_, so it is only available on Unix.
+The ``zoneinfo`` module is new in Python 3.8 - on older Python versions use the |backports-zoneinfo-package|_, by the original ``zoneinfo`` author.
 
 .. |zoneinfo-instance2| replace:: ``zoneinfo.ZoneInfo`` instance
 .. _zoneinfo-instance2: https://docs.python.org/3/library/zoneinfo.html#zoneinfo.ZoneInfo
@@ -202,7 +203,11 @@ This will be done by calling |time-tzset|_ (only available on Unix) and thus aff
 .. |time-tzset| replace:: ``time.tzset()``
 .. _time-tzset: https://docs.python.org/3/library/time.html#time.tzset
 
-time-machine won’t affect other concepts of “the current timezone”, such as Django’s (which can be changed with its |timezone-override|_).
+.. |backports-zoneinfo-package| replace:: ``backports.zoneinfo`` package
+.. _backports-zoneinfo-package: https://pypi.org/project/backports.zoneinfo/
+
+``time.tzset()`` changes the ``time`` module’s `timezone constants <https://docs.python.org/3/library/time.html#timezone-constants>`__ and features that rely on those, such as ``time.localtime()``.
+It won’t affect other concepts of “the current timezone”, such as Django’s (which can be changed with its |timezone-override|_).
 
 .. |timezone-override| replace:: ``time.override()``
 .. _timezone-override: https://docs.djangoproject.com/en/stable/ref/utils/#django.utils.timezone.override

--- a/src/time_machine.py
+++ b/src/time_machine.py
@@ -118,19 +118,8 @@ else:
 
 
 class travel:
-    def __init__(self, destination, *, tick=True, tz_offset=None):
-        destination_timestamp = destination_to_timestamp(destination)
-
-        if tz_offset is not None:
-            if isinstance(tz_offset, dt.timedelta):
-                tz_offset = tz_offset.total_seconds()
-
-            if not isinstance(tz_offset, (float, int)):
-                raise TypeError(f"Unsupported tz_offset {tz_offset!r}")
-
-            destination_timestamp += tz_offset
-
-        self.destination_timestamp = destination_timestamp
+    def __init__(self, destination, *, tick=True):
+        self.destination_timestamp = destination_to_timestamp(destination)
         self.tick = tick
 
     def start(self):

--- a/src/time_machine.py
+++ b/src/time_machine.py
@@ -6,6 +6,7 @@ import sys
 import uuid
 from time import tzset
 from types import GeneratorType
+from typing import Optional
 from unittest import TestCase, mock
 
 import _time_machine
@@ -19,49 +20,53 @@ except ImportError:
     # Dummy value that won't compare equal to any value
     CLOCK_REALTIME = float("inf")
 
+try:
+    # Python 3.8+ or have installed backports.zoneinfo
+    from zoneinfo import ZoneInfo
+except ImportError:
+    ZoneInfo = None
+
 NANOSECONDS_PER_SECOND = 1_000_000_000
 
 
-def destination_to_timestamp(destination):
+def extract_timestamp_tzname(destination):
     if callable(destination):
         destination = destination()
     elif isinstance(destination, GeneratorType):
         destination = next(destination)
 
+    tzname = None
     if isinstance(destination, (int, float)):
-        destination_timestamp = destination
+        timestamp = destination
     elif isinstance(destination, dt.datetime):
+        if ZoneInfo is not None and isinstance(destination.tzinfo, ZoneInfo):
+            tzname = destination.tzinfo.key
         if destination.tzinfo is None:
             destination = destination.replace(tzinfo=dt.timezone.utc)
-        destination_timestamp = destination.timestamp()
+        timestamp = destination.timestamp()
     elif isinstance(destination, dt.date):
-        destination_timestamp = dt.datetime.combine(
+        timestamp = dt.datetime.combine(
             destination, dt.time(0, 0), tzinfo=dt.timezone.utc
         ).timestamp()
     elif isinstance(destination, str):
-        destination_timestamp = parse_datetime(destination).timestamp()
+        timestamp = parse_datetime(destination).timestamp()
     else:
         raise TypeError(f"Unsupported destination {destination!r}")
 
-    return destination_timestamp
-
-
-def timezone_to_name(timezone):
-    if timezone is None:
-        return None
-    elif isinstance(timezone, str):
-        name = timezone
-    else:
-        raise TypeError(f"Unsupported timezone {timezone!r}")
-
-    return name
+    return timestamp, tzname
 
 
 class Coordinates:
-    def __init__(self, destination_timestamp: float, tick: bool):
+    def __init__(
+        self,
+        destination_timestamp: float,
+        destination_tzname: Optional[str],
+        tick: bool,
+    ):
         self._destination_timestamp_ns = int(
             destination_timestamp * NANOSECONDS_PER_SECOND
         )
+        self._destination_tzname = destination_tzname
         self._tick = tick
         self._requested = False
 
@@ -102,10 +107,25 @@ class Coordinates:
         self._destination_timestamp_ns += total_seconds * NANOSECONDS_PER_SECOND
 
     def move_to(self, destination):
-        self._destination_timestamp_ns = (
-            destination_to_timestamp(destination) * NANOSECONDS_PER_SECOND
-        )
+        self._stop()
+        timestamp, self._destination_tzname = extract_timestamp_tzname(destination)
+        self._destination_timestamp_ns = timestamp * NANOSECONDS_PER_SECOND
         self._requested = False
+        self._start()
+
+    def _start(self):
+        if self._destination_tzname is not None:
+            self._orig_tz = os.environ.get("TZ")
+            os.environ["TZ"] = self._destination_tzname
+            tzset()
+
+    def _stop(self):
+        if self._destination_tzname is not None:
+            if self._orig_tz is None:
+                del os.environ["TZ"]
+            else:
+                os.environ["TZ"] = self._orig_tz
+            tzset()
 
 
 coordinates_stack = []
@@ -131,9 +151,10 @@ else:
 
 
 class travel:
-    def __init__(self, destination, *, timezone=None, tick=True):
-        self.destination_timestamp = destination_to_timestamp(destination)
-        self.timezone_name = timezone_to_name(timezone)
+    def __init__(self, destination, *, tick=True):
+        self.destination_timestamp, self.destination_tzname = extract_timestamp_tzname(
+            destination
+        )
         self.tick = tick
 
     def start(self):
@@ -148,27 +169,17 @@ class travel:
 
         coordinates = Coordinates(
             destination_timestamp=self.destination_timestamp,
+            destination_tzname=self.destination_tzname,
             tick=self.tick,
         )
         coordinates_stack.append(coordinates)
-
-        if self.timezone_name is not None:
-            self.orig_tz = os.environ.get("TZ")
-            os.environ["TZ"] = self.timezone_name
-            tzset()
+        coordinates._start()
 
         return coordinates
 
     def stop(self):
         global coordinates_stack
-        coordinates_stack = coordinates_stack[:-1]
-
-        if self.timezone_name is not None:
-            if self.orig_tz is None:
-                del os.environ["TZ"]
-            else:
-                os.environ["TZ"] = self.orig_tz
-            tzset()
+        coordinates_stack.pop()._stop()
 
         if not coordinates_stack:
             uuid_generate_time_patcher.stop()

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -423,6 +423,48 @@ class UnitTestClassSetUpClassSkipTests(TestCase):
         pass
 
 
+# timezone tests
+
+
+def test_timezone_string():
+    orig_timezone = time.timezone
+    orig_altzone = time.altzone
+    orig_tzname = time.tzname
+    orig_daylight = time.daylight
+
+    with time_machine.travel(LIBRARY_EPOCH, timezone="Africa/Addis_Ababa"):
+        assert time.timezone == -3 * 3600
+        assert time.altzone == -3 * 3600
+        assert time.tzname == ("EAT", "EAT")
+        assert time.daylight == 0
+
+        assert time.localtime() == time.struct_time(
+            (
+                2020,
+                4,
+                29,
+                2,
+                0,
+                0,
+                2,
+                120,
+                0,
+            )
+        )
+
+    assert time.timezone == orig_timezone
+    assert time.altzone == orig_altzone
+    assert time.tzname == orig_tzname
+    assert time.daylight == orig_daylight
+
+
+def test_timezone_unsupported_type():
+    with pytest.raises(TypeError) as excinfo:
+        time_machine.travel(LIBRARY_EPOCH, timezone=[])
+
+    assert excinfo.value.args == ("Unsupported timezone []",)
+
+
 # shift() tests
 
 

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -423,27 +423,6 @@ class UnitTestClassSetUpClassSkipTests(TestCase):
         pass
 
 
-# tz_offset tests
-
-
-def test_tz_offset_float():
-    with time_machine.travel(EPOCH, tz_offset=3600.0):
-        assert time.time() == EPOCH + 3600.0
-
-
-def test_tz_offset_timedelta():
-    with time_machine.travel(EPOCH, tz_offset=dt.timedelta(hours=5.5)):
-        assert time.time() == EPOCH + (5.5 * 3600.0)
-
-
-def test_tz_offset_unsupported_type():
-    with pytest.raises(TypeError) as excinfo:
-        with time_machine.travel(EPOCH, tz_offset="something"):
-            pass
-
-    assert excinfo.value.args == ("Unsupported tz_offset 'something'",)
-
-
 # shift() tests
 
 

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -343,6 +343,23 @@ def test_destination_datetime_tzinfo_zoneinfo():
     assert time.daylight == orig_daylight
 
 
+@pytest.mark.skipif(ZoneInfo is None, reason="Requires ZoneInfo")
+def test_destination_datetime_tzinfo_zoneinfo_nested():
+    orig_tzname = time.tzname
+
+    dest = LIBRARY_EPOCH_DATETIME.replace(tzinfo=ZoneInfo("Africa/Addis_Ababa"))
+    with time_machine.travel(dest):
+        assert time.tzname == ("EAT", "EAT")
+
+        dest2 = LIBRARY_EPOCH_DATETIME.replace(tzinfo=ZoneInfo("Pacific/Auckland"))
+        with time_machine.travel(dest2):
+            assert time.tzname == ("NZST", "NZDT")
+
+        assert time.tzname == ("EAT", "EAT")
+
+    assert time.tzname == orig_tzname
+
+
 @time_machine.travel(EPOCH_DATETIME.replace(tzinfo=None) + dt.timedelta(seconds=120))
 def test_destination_datetime_naive():
     assert time.time() == EPOCH + 120.0


### PR DESCRIPTION
Rather than try fix `tz_offset`, remove it and replace it with complete timezone mocking, after deliberation in #65 .