### PR TITLE
Update wheel building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,27 +14,34 @@ jobs:
       matrix:
         os:
         - ubuntu-20.04
-        - windows-latest
-        - macos-latest
+        - windows-2019
+        - macos-10.15
 
     env:
+      CIBW_ARCHS_LINUX: x86_64 i686 aarch64
       CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-*"
 
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/setup-python@v2
         with:
           python-version: '3.9'
+
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==1.7.2
-      - name: Install Visual C++ for Python 2.7
-        if: runner.os == 'Windows'
-        run: |
-          choco install vcpython27 -f -y
+          python -m pip install cibuildwheel==1.9.0
+
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
+
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,8 @@
 History
 =======
 
+* Release now includes wheels for ARM on Linux.
+
 2.0.1 (2021-01-18)
 ------------------
 


### PR DESCRIPTION
* Pin OS versions
* build for multiple linux architectures - fixes #110
* Don't install Visual C++ for Python 2.7 on windows - we aren't using Python 2.7, don't know how this would have been useful?