### PR TITLE
Fix isort config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ target-version = ['py36']
 
 [tool.isort]
 profile = "black"
+known_first_party = "_time_machine"
 
 [tool.mypy]
 check_untyped_defs = true

--- a/src/time_machine/__init__.py
+++ b/src/time_machine/__init__.py
@@ -13,8 +13,9 @@ from typing import Generator as TypingGenerator
 from typing import List, Optional, Tuple, Type, Union, overload
 from unittest import TestCase, mock
 
-import _time_machine
 from dateutil.parser import parse as parse_datetime
+
+import _time_machine
 
 # time.clock_gettime and time.CLOCK_REALTIME not always available
 # e.g. on builds against old macOS = official Python.org installer


### PR DESCRIPTION
For whatever reason isort on pre-commit.ci is picking up _time_machine as third party, whilst locally it's not. To stabilize import sorting, declare it as always first party.