### PR TITLE
Add github actions to test non-UTC environments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,17 +8,26 @@ on:
 
 jobs:
   tests:
-    name: Python ${{ matrix.python-version }}
+    name: Python ${{ matrix.python-version }} (TZ = ${{ matrix.env.TZ }})
     runs-on: ubuntu-20.04
 
     strategy:
       matrix:
         python-version:
-        - 3.6
-        - 3.7
-        - 3.8
-        - 3.9
-        - 3.10-dev
+          - 3.6
+          - 3.7
+          - 3.8
+          - 3.9
+          - 3.10-dev
+        env:
+          - TZ: "UTC"
+        include:
+          - python-version: 3.9
+            env:
+              TZ: "America/New_York"
+          - python-version: 3.9
+            env:
+              TZ: "Australia/Sydney"
 
     steps:
     - uses: actions/checkout@v2
@@ -33,6 +42,10 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements/*.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
+
+    - name: Set time zone
+      run: |
+        sudo timedatectl set-timezone ${{ matrix.env.TZ }}
 
     - name: Install dependencies
       run: |

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
 
 [testenv]
 commands = python -W error::DeprecationWarning -W error::PendingDeprecationWarning -m coverage run --parallel -m pytest {posargs}
+passenv = TZ
 
 [testenv:py36]
 deps = -rrequirements/py36.txt


### PR DESCRIPTION
Currently many of the tests involving local times are failing in `America/New_York`, because they assume that the date on `time.localtime(EPOCH)` is always going to be 1970-01-01, which is not true west of UTC.

This PR is a demonstration of this, and can serve as a regression test when it is fixed.