### PR TITLE
Stop building wheels on PR's

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - main
-  pull_request:
 
 jobs:
   build_wheels:


### PR DESCRIPTION
They're only needed on the main branch during release. Building them on every PR is safe but wastes a lot of time.