### PR TITLE
Support non-unittest class decoration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -178,8 +178,7 @@ When used as a context manager, time is mocked during the ``with`` block:
 Class Decorator
 ^^^^^^^^^^^^^^^
 
-Only ``unittest.TestCase`` subclasses are supported.
-When applied as a class decorator to such classes, time is mocked from the start of ``setUpClass()`` to the end of ``tearDownClass()``:
+Decorating a ``unittest.TestCase`` subclass will mock time from the start of ``setUpClass()`` to the end of ``tearDownClass()``:
 
 .. code-block:: python
 
@@ -194,6 +193,22 @@ When applied as a class decorator to such classes, time is mocked from the start
             assert 0.0 < time.time() < 1.0
 
 Note this is different to ``unittest.mock.patch()``\'s behaviour, which is to mock only during the test methods.
+
+Any other class can also be decorated - time will be mocked for each method with a name starting with ``test``:
+
+.. code-block:: python
+
+    import time
+    import time_machine
+
+
+    @time_machine.travel(0.0)
+    class TestDeepPast:
+        def test_in_the_deep_past(self):
+            assert 0.0 < time.time() < 1.0
+
+        def not_a_test(self):
+            assert not 0.0 < time.time() < 1.0
 
 Timezone mocking
 ^^^^^^^^^^^^^^^^

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -487,14 +487,35 @@ def test_coroutine_decorator():
     assert recorded_time == EPOCH + 140.0
 
 
-def test_class_decorator_fails_non_testcase():
-    with pytest.raises(TypeError) as excinfo:
+@time_machine.travel(EPOCH)
+def test_non_unittest_class_decorator():
+    @time_machine.travel(EPOCH + 25.0)
+    class NonUnitTestClassTests:
+        def test_class_decorator(self):
+            assert time.time() == EPOCH + 25.0
 
-        @time_machine.travel(EPOCH)
-        class Something:
-            pass
+    NonUnitTestClassTests().test_class_decorator()
 
-    assert excinfo.value.args == ("Can only decorate unittest.TestCase subclasses.",)
+
+@time_machine.travel(EPOCH)
+def test_non_unittest_class_decorator_ignores_non_tests():
+    @time_machine.travel(EPOCH + 25.0)
+    class NonUnitTestClassTests:
+        def not_a_test(self):
+            assert time.time() == EPOCH
+
+    NonUnitTestClassTests().not_a_test()
+
+
+@time_machine.travel(EPOCH)
+def test_non_unittest_class_decorator_ignores_nested_classes():
+    @time_machine.travel(EPOCH + 25.0)
+    class NonUnitTestClassTests:
+        class test_class:
+            def test(self):
+                assert time.time() == EPOCH
+
+    NonUnitTestClassTests().test_class().test()
 
 
 class MethodDecoratorTests:


### PR DESCRIPTION
Contributes towards #20 by allowing any class to be decorated.

All methods starting with `test` on a decorated class are wrapped.