### PR TITLE
[minor] Fix name of Django module in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -216,7 +216,7 @@ The ``zoneinfo`` module is new in Python 3.8 - on older Python versions use the 
 ``time.tzset()`` changes the ``time`` module’s `timezone constants <https://docs.python.org/3/library/time.html#timezone-constants>`__ and features that rely on those, such as ``time.localtime()``.
 It won’t affect other concepts of “the current timezone”, such as Django’s (which can be changed with its |timezone-override|_).
 
-.. |timezone-override| replace:: ``time.override()``
+.. |timezone-override| replace:: ``timezone.override()``
 .. _timezone-override: https://docs.djangoproject.com/en/stable/ref/utils/#django.utils.timezone.override
 
 Here’s a worked example changing the current timezone:


### PR DESCRIPTION
Django's module is called `timezone`, not `time`.

I got confused when reading the README (on PyPI) and thought there was a new module in Django that I hadn't heard about.

Thanks! ✨ 