### PR TITLE
doc: Remove unnecessary yield in pytest example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -327,7 +327,6 @@ If you are using pytest test classes, you can apply the fixture to all test meth
         @pytest.fixture(autouse=True)
         def set_time(self, time_machine):
             time_machine.move_to(1000.0)
-            yield
 
         def test_one(self):
             assert int(time.time()) == 1000.0


### PR DESCRIPTION
pytest uses `yield` to do cleanup from fixture functions: https://docs.pytest.org/en/7.1.x/how-to/fixtures.html#yield-fixtures-recommended

However, the fixture given in the readme does not do any cleanup steps at all, so there is no need for it to `yield`.