### PR TITLE
fix: build wheels for Python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       CIBW_ARCHS_LINUX: x86_64 i686 aarch64
       CIBW_ARCHS_MACOS: x86_64 universal2
-      CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-* cp310-* cp310-*"
+      CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-*"
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Use the correct version specifier to build wheels on Python 3.11 (`cp310-*` was specified instead of `cp311-*`).