### PR TITLE
Add support for as_kwarg parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,22 @@ If ``True``, the default, successive calls to mocked functions return values inc
 So after starting travel to ``0.0`` (the UNIX epoch), the first call to any datetime function will return its representation of ``1970-01-01 00:00:00.000000`` exactly.
 The following calls "tick," so if a call was made exactly half a second later, it would return ``1970-01-01 00:00:00.500000``.
 
+``as_kwarg`` is a str optional parameter that can be used when ``travel`` is used as a method decorator to pass the ``Coordinates`` context to the underlying method.
+
+.. code-block:: python
+
+    import datetime as dt
+    import time_machine
+    from unittest import TestCase
+
+    class TimeMachineTestCase(TestCase):
+
+        @time_machine.travel(dt.datetime(1985, 10, 26, 1, 24), as_kwarg="traveller")
+        def test_delorean(self, traveller):
+            assert dt.date.today().isoformat() == "1985-10-26"
+
+            traveller.move_to(dt.datetime(1985, 12, 0, 0, 0))
+
 Mocked Functions
 ^^^^^^^^^^^^^^^^
 

--- a/README.rst
+++ b/README.rst
@@ -102,8 +102,8 @@ The following calls "tick," so if a call was made exactly half a second later, i
     import time_machine
     from unittest import TestCase
 
-    class TimeMachineTestCase(TestCase):
 
+    class TimeMachineTestCase(TestCase):
         @time_machine.travel(dt.datetime(1985, 10, 26, 1, 24), as_kwarg="traveller")
         def test_delorean(self, traveller):
             assert dt.date.today().isoformat() == "1985-10-26"

--- a/src/time_machine/__init__.py
+++ b/src/time_machine/__init__.py
@@ -211,7 +211,13 @@ uuid_idempotent_load_system_functions = (
 
 
 class travel:
-    def __init__(self, destination: DestinationType, *, tick: bool = True, as_kwarg: str | None = None) -> None:
+    def __init__(
+        self,
+        destination: DestinationType,
+        *,
+        tick: bool = True,
+        as_kwarg: str | None = None,
+    ) -> None:
         self.destination_timestamp, self.destination_tzname = extract_timestamp_tzname(
             destination
         )

--- a/src/time_machine/__init__.py
+++ b/src/time_machine/__init__.py
@@ -211,11 +211,12 @@ uuid_idempotent_load_system_functions = (
 
 
 class travel:
-    def __init__(self, destination: DestinationType, *, tick: bool = True) -> None:
+    def __init__(self, destination: DestinationType, *, tick: bool = True, as_kwarg: str | None = None) -> None:
         self.destination_timestamp, self.destination_tzname = extract_timestamp_tzname(
             destination
         )
         self.tick = tick
+        self.as_kwarg = as_kwarg
 
     def start(self) -> Coordinates:
         global coordinates_stack
@@ -329,7 +330,9 @@ class travel:
 
             @functools.wraps(wrapped)
             def wrapper(*args: Any, **kwargs: Any) -> Any:
-                with self:
+                with self as traveller:
+                    if self.as_kwarg:
+                        kwargs[self.as_kwarg] = traveller
                     return wrapped(*args, **kwargs)
 
             return wrapper

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -496,6 +496,16 @@ class UnitTestMethodTests(TestCase):
         assert time.time() == EPOCH + 25.0
 
 
+class UnitTestMethodAsKwargTests(TestCase):
+    @time_machine.travel(EPOCH, as_kwarg="traveller")
+    def test_method_decorator(self, traveller):
+        assert time.time() == EPOCH
+
+        traveller.move_to(EPOCH_PLUS_ONE_YEAR_DATETIME)
+
+        assert time.time() == EPOCH_PLUS_ONE_YEAR
+
+
 @time_machine.travel(EPOCH + 95.0)
 class UnitTestClassTests(TestCase):
     def test_class_decorator(self):


### PR DESCRIPTION
This syntax comes from [freezegun](https://github.com/spulec/freezegun). Supporting it will make it easier for people to compare and switch from freezegun.