### PR TITLE
Improve travel() type hints to preserve wrapped type

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,8 @@
 History
 =======
 
+* Improve type hints for ``time_machine.travel()`` to preserve the types of the wrapped function/coroutine/class.
+
 2.8.1 (2022-08-16)
 ------------------
 


### PR DESCRIPTION
Tested with this example file:

```
import time_machine

from unittest import TestCase


@time_machine.travel(1)
def f() -> int:
    return 123


reveal_type(f)


@time_machine.travel(1)
async def g() -> int:
    return 123


reveal_type(g)


@time_machine.travel(1)
class MyTests(TestCase):
    xxx: int


reveal_type(MyTests)
reveal_type(MyTests.xxx)
```

Before the `reveal_types` would only show generic types, now they show the original signatures.