### PR TITLE
remove unnecessary try/finally block from the pytest fixture

### DIFF
--- a/src/time_machine/__init__.py
+++ b/src/time_machine/__init__.py
@@ -441,10 +441,8 @@ if HAVE_PYTEST:  # pragma: no branch
     @pytest.fixture(name="time_machine")
     def time_machine_fixture() -> TypingGenerator[TimeMachineFixture, None, None]:
         fixture = TimeMachineFixture()
-        try:
-            yield fixture
-        finally:
-            fixture.stop()
+        yield fixture
+        fixture.stop()
 
 
 # escape hatch


### PR DESCRIPTION
It is a misunderstanding of [yield fixtures](https://docs.pytest.org/en/6.2.x/fixture.html#handling-errors-for-yield-fixture) that the teardown must be handled in a finally block. It is the responsibility of the test runner itself to handle the case where code under test raises any kind of exception, and pytest will execute the teardown (i.e. `fixture.stop()` here) regardless of whether the code we yield to has raised or not.