### PR TITLE
Add support for dt.timedelta to travel class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* Add support for ``datetime.timedelta`` to ``time_machine.travel()``.
+
+  Thanks to Nate Dudenhoeffer in `PR #298 <https://github.com/adamchainz/time-machine/pull/298>`__.
+
 * Add ``shift()`` method to the ``time_machine`` pytest fixture.
 
   Thanks to Stefaan Lippens in `PR #312 <https://github.com/adamchainz/time-machine/pull/312>`__.

--- a/README.rst
+++ b/README.rst
@@ -77,10 +77,12 @@ It may be:
   If it has ``tzinfo`` set to a |zoneinfo-instance|_, the current timezone will also be mocked.
 * A ``datetime.date``.
   This will be converted to a UTC datetime with the time 00:00:00.
+* A ``datetime.timedelta``.
+  This will be interpreted relative to the current time.
+  If already within a ``travel()`` block, the ``shift()`` method is easier to use (documented below).
 * A ``float`` or ``int`` specifying a `Unix timestamp <https://en.m.wikipedia.org/wiki/Unix_time>`__
 * A string, which will be parsed with `dateutil.parse <https://dateutil.readthedocs.io/en/stable/parser.html>`__ and converted to a timestamp.
   Again, if the result is naive, it will be assumed to have the UTC time zone.
-* A ``datetime.timedelta`` relative to the current real time.
 
 .. |zoneinfo-instance| replace:: ``zoneinfo.ZoneInfo`` instance
 .. _zoneinfo-instance: https://docs.python.org/3/library/zoneinfo.html#zoneinfo.ZoneInfo

--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,7 @@ It may be:
 * A ``float`` or ``int`` specifying a `Unix timestamp <https://en.m.wikipedia.org/wiki/Unix_time>`__
 * A string, which will be parsed with `dateutil.parse <https://dateutil.readthedocs.io/en/stable/parser.html>`__ and converted to a timestamp.
   Again, if the result is naive, it will be assumed to have the UTC time zone.
+* A ``datetime.timedelta`` relative to the current real time.
 
 .. |zoneinfo-instance| replace:: ``zoneinfo.ZoneInfo`` instance
 .. _zoneinfo-instance: https://docs.python.org/3/library/zoneinfo.html#zoneinfo.ZoneInfo

--- a/src/time_machine/__init__.py
+++ b/src/time_machine/__init__.py
@@ -84,6 +84,7 @@ DestinationBaseType = Union[
     int,
     float,
     dt.datetime,
+    dt.timedelta,
     dt.date,
     str,
 ]
@@ -124,6 +125,12 @@ def extract_timestamp_tzname(
         if dest.tzinfo is None:
             dest = dest.replace(tzinfo=dt.timezone.utc)
         timestamp = dest.timestamp()
+    elif isinstance(dest, dt.timedelta):
+        if coordinates_stack:
+            raise TypeError(
+                "timedelta destination is not supported when already time travelling."
+            )
+        timestamp = time() + dest.total_seconds()
     elif isinstance(dest, dt.date):
         timestamp = dt.datetime.combine(
             dest, dt.time(0, 0), tzinfo=dt.timezone.utc

--- a/src/time_machine/__init__.py
+++ b/src/time_machine/__init__.py
@@ -126,10 +126,6 @@ def extract_timestamp_tzname(
             dest = dest.replace(tzinfo=dt.timezone.utc)
         timestamp = dest.timestamp()
     elif isinstance(dest, dt.timedelta):
-        if coordinates_stack:
-            raise TypeError(
-                "timedelta destination is not supported when already time travelling."
-            )
         timestamp = time() + dest.total_seconds()
     elif isinstance(dest, dt.date):
         timestamp = dt.datetime.combine(

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -476,14 +476,10 @@ def test_destination_negative_delta():
         assert now - 3600 <= time.time() <= now - 3599
 
 
-@time_machine.travel(0)
 def test_destination_delta_raises():
-    with pytest.raises(TypeError) as excinfo:
-        time_machine.travel(dt.timedelta(seconds=3600))
-
-    assert excinfo.value.args == (
-        "Timedelta destination is not supported when already time travelling.",
-    )
+    with time_machine.travel(EPOCH):
+        with time_machine.travel(dt.timedelta(seconds=10)):
+            assert time.time() == EPOCH + 10.0
 
 
 def test_traveller_object():

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -467,13 +467,13 @@ def test_destination_generator():
 def test_destination_delta():
     now = time.time()
     with time_machine.travel(dt.timedelta(seconds=3600)):
-        assert now + 3600 < time.time() < now + 3601
+        assert now + 3600 <= time.time() <= now + 3601
 
 
 def test_destination_negative_delta():
     now = time.time()
     with time_machine.travel(dt.timedelta(seconds=-3600)):
-        assert now - 3600 < time.time() < now - 3599
+        assert now - 3600 <= time.time() <= now - 3599
 
 
 @time_machine.travel(0)

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -444,6 +444,24 @@ def test_destination_date():
     assert time.time() == EPOCH
 
 
+def test_destination_timedelta():
+    now = time.time()
+    with time_machine.travel(dt.timedelta(seconds=3600)):
+        assert now + 3600 <= time.time() <= now + 3601
+
+
+def test_destination_timedelta_negative():
+    now = time.time()
+    with time_machine.travel(dt.timedelta(seconds=-3600)):
+        assert now - 3600 <= time.time() <= now - 3599
+
+
+def test_destination_timedelta_nested():
+    with time_machine.travel(EPOCH):
+        with time_machine.travel(dt.timedelta(seconds=10)):
+            assert time.time() == EPOCH + 10.0
+
+
 @time_machine.travel("1970-01-01 00:01 +0000")
 def test_destination_string():
     assert time.time() == EPOCH + 60.0
@@ -462,24 +480,6 @@ def test_destination_callable_lambda_string():
 @time_machine.travel(EPOCH + 13.0 for _ in range(1))  # pragma: no branch
 def test_destination_generator():
     assert time.time() == EPOCH + 13.0
-
-
-def test_destination_delta():
-    now = time.time()
-    with time_machine.travel(dt.timedelta(seconds=3600)):
-        assert now + 3600 <= time.time() <= now + 3601
-
-
-def test_destination_negative_delta():
-    now = time.time()
-    with time_machine.travel(dt.timedelta(seconds=-3600)):
-        assert now - 3600 <= time.time() <= now - 3599
-
-
-def test_destination_delta_raises():
-    with time_machine.travel(EPOCH):
-        with time_machine.travel(dt.timedelta(seconds=10)):
-            assert time.time() == EPOCH + 10.0
 
 
 def test_traveller_object():

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -464,6 +464,28 @@ def test_destination_generator():
     assert time.time() == EPOCH + 13.0
 
 
+def test_destination_delta():
+    now = time.time()
+    with time_machine.travel(dt.timedelta(seconds=3600)):
+        assert now + 3600 < time.time() < now + 3601
+
+
+def test_destination_negative_delta():
+    now = time.time()
+    with time_machine.travel(dt.timedelta(seconds=-3600)):
+        assert now - 3600 < time.time() < now - 3599
+
+
+@time_machine.travel(0)
+def test_destination_delta_raises():
+    with pytest.raises(TypeError) as excinfo:
+        time_machine.travel(dt.timedelta(seconds=3600))
+
+    assert excinfo.value.args == (
+        "Timedelta destination is not supported when already time travelling.",
+    )
+
+
 def test_traveller_object():
     traveller = time_machine.travel(EPOCH + 10.0)
     assert time.time() >= LIBRARY_EPOCH


### PR DESCRIPTION
Adds support to pass a datetime.timedelta object to `travel`.

To avoid potential abuse this feature is blocked when already traveling, since the `shift` API would provide similar functionality and should be simpler.

This should open an API to implement #247

fixes #38 