### PR TITLE
Move from isort to reorder-python-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,16 @@ repos:
   - id: blacken-docs
     additional_dependencies:
     - black==22.10.0
-- repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v3.9.0
   hooks:
-  - id: isort
+  - id: reorder-python-imports
+    args:
+    - --py37-plus
+    - --application-directories
+    - .:example:src
+    - --add-import
+    - 'from __future__ import annotations'
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 target-version = ['py37']
 
-[tool.isort]
-profile = "black"
-add_imports = "from __future__ import annotations"
-known_first_party = "_time_machine"
-
 [tool.mypy]
 mypy_path = "src/"
 show_error_codes = true

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
-from setuptools import Extension, setup
+from setuptools import Extension
+from setuptools import setup
 
 setup(ext_modules=[Extension(name="_time_machine", sources=["src/_time_machine.c"])])

--- a/src/time_machine/__init__.py
+++ b/src/time_machine/__init__.py
@@ -10,14 +10,21 @@ from collections.abc import Generator
 from time import gmtime as orig_gmtime
 from time import struct_time
 from types import TracebackType
-from typing import Any, Awaitable, Callable
+from typing import Any
+from typing import Awaitable
+from typing import Callable
+from typing import cast
 from typing import Generator as TypingGenerator
-from typing import Tuple, Type, TypeVar, Union, cast, overload
-from unittest import TestCase, mock
-
-from dateutil.parser import parse as parse_datetime
+from typing import overload
+from typing import Tuple
+from typing import Type
+from typing import TypeVar
+from typing import Union
+from unittest import mock
+from unittest import TestCase
 
 import _time_machine
+from dateutil.parser import parse as parse_datetime
 
 # time.clock_gettime and time.CLOCK_REALTIME not always available
 # e.g. on builds against old macOS = official Python.org installer

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -6,8 +6,11 @@ import os
 import sys
 import time
 import uuid
-from importlib.util import module_from_spec, spec_from_file_location
-from unittest import SkipTest, TestCase, mock
+from importlib.util import module_from_spec
+from importlib.util import spec_from_file_location
+from unittest import mock
+from unittest import SkipTest
+from unittest import TestCase
 
 import pytest
 from dateutil import tz


### PR DESCRIPTION
It’s [way faster](https://twitter.com/codewithanthony/status/1553034384206438401) and its one-import-per-line style prevents merge conflicts.
