### PR TITLE
Fix docs on timezone of naive date(time) strings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ Changelog
 
   Thanks to Nate Dudenhoeffer in `PR #298 <https://github.com/adamchainz/time-machine/pull/298>`__.
 
+* Fix documentation about using local time for naive date(time) strings.
+
+  Thanks to Stefaan Lippens in `PR #306 <https://github.com/adamchainz/time-machine/pull/306>`__.
+
 * Add ``shift()`` method to the ``time_machine`` pytest fixture.
 
   Thanks to Stefaan Lippens in `PR #312 <https://github.com/adamchainz/time-machine/pull/312>`__.

--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ It may be:
   If already within a ``travel()`` block, the ``shift()`` method is easier to use (documented below).
 * A ``float`` or ``int`` specifying a `Unix timestamp <https://en.m.wikipedia.org/wiki/Unix_time>`__
 * A string, which will be parsed with `dateutil.parse <https://dateutil.readthedocs.io/en/stable/parser.html>`__ and converted to a timestamp.
-  Again, if the result is naive, it will be assumed to have the UTC time zone.
+  If the result is naive, it will be assumed to be local time.
 
 .. |zoneinfo-instance| replace:: ``zoneinfo.ZoneInfo`` instance
 .. _zoneinfo-instance: https://docs.python.org/3/library/zoneinfo.html#zoneinfo.ZoneInfo


### PR DESCRIPTION
Addresses the documentation issue raised in #257:
passing a naive date string to `travel` will be interpreted as local time