### PR TITLE
Throw an explicit error when trying to build on PyPy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,10 @@ from setuptools import setup
 
 
 if hasattr(sys, "pypy_version_info"):
-    raise RuntimeError("PyPy is not currently supported by time-machine, see "
-                       "https://github.com/adamchainz/time-machine/issues/305")
+    raise RuntimeError(
+        "PyPy is not currently supported by time-machine, see "
+        "https://github.com/adamchainz/time-machine/issues/305"
+    )
 
 
 setup(ext_modules=[Extension(name="_time_machine", sources=["src/_time_machine.c"])])

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
+import sys
+
 from setuptools import Extension
 from setuptools import setup
+
+
+if hasattr(sys, "pypy_version_info"):
+    raise RuntimeError("PyPy is not currently supported by time-machine, see "
+                       "https://github.com/adamchainz/time-machine/issues/305")
+
 
 setup(ext_modules=[Extension(name="_time_machine", sources=["src/_time_machine.c"])])


### PR DESCRIPTION
Since PyPy is currently unsupported, throw an explicit error when one attempts to build time-machine.  This should prevent packages from trying to use time-machine which can cause segfaults at runtime.

See issue #305