### PR TITLE
Build wheels for Python 3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.13.1
+          python -m pip install cibuildwheel==2.15.0
 
       - name: Set up QEMU
         if: runner.os == 'Linux'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* Include wheels for Python 3.12.
+
 2.11.0 (2023-07-10)
 -------------------
 


### PR DESCRIPTION
Thanks to new cibuildwheel: https://github.com/pypa/cibuildwheel/releases/tag/v2.15.0