### PR TITLE
Monotonic overhaul

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -273,6 +273,12 @@ For example:
         traveller.move_to(234)
         assert time.time() == 234
 
+By default, ``move_to()`` does not affect ``time.monotonic``, but passing
+``affect_monotonic=True`` allows to let monotonic timer to get moved.
+However, be aware than by doing so, ``time.monotonic`` may step back in time
+either whem moving to an earlier date or when exiting the travel context,
+breaking everything depending on its monotonic behaviour.
+
 ``shift(delta)``
 ^^^^^^^^^^^^^^^^
 
@@ -296,6 +302,12 @@ For example:
 
         traveller.shift(-dt.timedelta(seconds=10))
         assert time.time() == 90
+
+By default, ``shift()`` does not affect ``time.monotonic``, but passing
+``affect_monotonic=True`` allows to let monotonic timer get affected by
+``shift``.
+However, be aware than by doing so, monotonic may step back in time when
+exiting travel, breaking everything depending on its monotonic behaviour.
 
 pytest plugin
 -------------

--- a/src/_time_machine.c
+++ b/src/_time_machine.c
@@ -251,6 +251,24 @@ Call time.localtime() after patching.");
 /* time.monotonic() */
 
 static PyObject*
+_time_machine_monotonic(PyObject *self, PyObject *args)
+{
+    PyObject *time_machine_module = PyImport_ImportModule("time_machine");
+    if (!time_machine_module) {
+        return NULL;
+    }
+    PyObject *time_machine_monotonic = PyObject_GetAttrString(
+        time_machine_module, "monotonic");
+
+    PyObject* result = PyObject_CallObject(time_machine_monotonic, args);
+
+    Py_DECREF(time_machine_monotonic);
+    Py_DECREF(time_machine_module);
+
+    return result;
+}
+
+static PyObject*
 _time_machine_original_monotonic(PyObject* module, PyObject* args)
 {
     _time_machine_state *state = get_time_machine_state(module);
@@ -269,6 +287,24 @@ PyDoc_STRVAR(original_monotonic_doc,
 Call time.monotonic() after patching.");
 
 /* time.monotonic_ns() */
+
+static PyObject*
+_time_machine_monotonic_ns(PyObject *self, PyObject *args)
+{
+    PyObject *time_machine_module = PyImport_ImportModule("time_machine");
+    if (!time_machine_module) {
+        return NULL;
+    }
+    PyObject *time_machine_monotonic_ns = PyObject_GetAttrString(
+        time_machine_module, "monotonic_ns");
+
+    PyObject* result = PyObject_CallObject(time_machine_monotonic_ns, args);
+
+    Py_DECREF(time_machine_monotonic_ns);
+    Py_DECREF(time_machine_module);
+
+    return result;
+}
 
 static PyObject*
 _time_machine_original_monotonic_ns(PyObject* module, PyObject* args)
@@ -457,12 +493,12 @@ _time_machine_patch_if_needed(PyObject *module, PyObject *unused)
 
     PyCFunctionObject *time_monotonic = (PyCFunctionObject *) PyObject_GetAttrString(time_module, "monotonic");
     state->original_monotonic = time_monotonic->m_ml->ml_meth;
-    time_monotonic->m_ml->ml_meth = _time_machine_time;
+    time_monotonic->m_ml->ml_meth = _time_machine_monotonic;
     Py_DECREF(time_monotonic);
 
     PyCFunctionObject *time_monotonic_ns = (PyCFunctionObject *) PyObject_GetAttrString(time_module, "monotonic_ns");
     state->original_monotonic_ns = time_monotonic_ns->m_ml->ml_meth;
-    time_monotonic_ns->m_ml->ml_meth = _time_machine_time_ns;
+    time_monotonic_ns->m_ml->ml_meth = _time_machine_monotonic_ns;
     Py_DECREF(time_monotonic_ns);
 
     PyCFunctionObject *time_strftime = (PyCFunctionObject *) PyObject_GetAttrString(time_module, "strftime");

--- a/src/_time_machine.c
+++ b/src/_time_machine.c
@@ -34,6 +34,8 @@ _time_machine_now(PyTypeObject *type, PyObject *const *args, Py_ssize_t nargs, P
     PyObject *result = NULL;
 
     PyObject *time_machine_module = PyImport_ImportModule("time_machine");
+    if (!time_machine_module)
+        return NULL;
     PyObject *time_machine_now = PyObject_GetAttrString(time_machine_module, "now");
 
     result = _PyObject_Vectorcall(time_machine_now, args, nargs, kwnames);
@@ -70,6 +72,8 @@ static PyObject*
 _time_machine_utcnow(PyObject *cls, PyObject *args)
 {
     PyObject *time_machine_module = PyImport_ImportModule("time_machine");
+    if (!time_machine_module)
+        return NULL;
     PyObject *time_machine_utcnow = PyObject_GetAttrString(time_machine_module, "utcnow");
 
     PyObject* result = PyObject_CallObject(time_machine_utcnow, args);
@@ -106,6 +110,8 @@ static PyObject*
 _time_machine_clock_gettime(PyObject *self, PyObject *args)
 {
     PyObject *time_machine_module = PyImport_ImportModule("time_machine");
+    if (!time_machine_module)
+        return NULL;
     PyObject *time_machine_clock_gettime = PyObject_GetAttrString(time_machine_module, "clock_gettime");
 
     PyObject* result = PyObject_CallObject(time_machine_clock_gettime, args);
@@ -140,6 +146,8 @@ static PyObject*
 _time_machine_clock_gettime_ns(PyObject *self, PyObject *args)
 {
     PyObject *time_machine_module = PyImport_ImportModule("time_machine");
+    if (!time_machine_module)
+        return NULL;
     PyObject *time_machine_clock_gettime_ns = PyObject_GetAttrString(time_machine_module, "clock_gettime_ns");
 
     PyObject* result = PyObject_CallObject(time_machine_clock_gettime_ns, args);
@@ -174,6 +182,8 @@ static PyObject*
 _time_machine_gmtime(PyObject *self, PyObject *args)
 {
     PyObject *time_machine_module = PyImport_ImportModule("time_machine");
+    if (!time_machine_module)
+        return NULL;
     PyObject *time_machine_gmtime = PyObject_GetAttrString(time_machine_module, "gmtime");
 
     PyObject* result = PyObject_CallObject(time_machine_gmtime, args);
@@ -208,6 +218,8 @@ static PyObject*
 _time_machine_localtime(PyObject *self, PyObject *args)
 {
     PyObject *time_machine_module = PyImport_ImportModule("time_machine");
+    if (!time_machine_module)
+        return NULL;
     PyObject *time_machine_localtime = PyObject_GetAttrString(time_machine_module, "localtime");
 
     PyObject* result = PyObject_CallObject(time_machine_localtime, args);
@@ -282,6 +294,8 @@ static PyObject*
 _time_machine_strftime(PyObject *self, PyObject *args)
 {
     PyObject *time_machine_module = PyImport_ImportModule("time_machine");
+    if (!time_machine_module)
+        return NULL;
     PyObject *time_machine_strftime = PyObject_GetAttrString(time_machine_module, "strftime");
 
     PyObject* result = PyObject_CallObject(time_machine_strftime, args);
@@ -316,6 +330,8 @@ static PyObject*
 _time_machine_time(PyObject *self, PyObject *args)
 {
     PyObject *time_machine_module = PyImport_ImportModule("time_machine");
+    if (!time_machine_module)
+        return NULL;
     PyObject *time_machine_time = PyObject_GetAttrString(time_machine_module, "time");
 
     PyObject* result = PyObject_CallObject(time_machine_time, args);
@@ -350,6 +366,8 @@ static PyObject*
 _time_machine_time_ns(PyObject *self, PyObject *args)
 {
     PyObject *time_machine_module = PyImport_ImportModule("time_machine");
+    if (!time_machine_module)
+        return NULL;
     PyObject *time_machine_time_ns = PyObject_GetAttrString(time_machine_module, "time_ns");
 
     PyObject* result = PyObject_CallObject(time_machine_time_ns, args);

--- a/src/time_machine/__init__.py
+++ b/src/time_machine/__init__.py
@@ -414,6 +414,20 @@ def time_ns() -> int:
     return coordinates_stack[-1].time_ns()
 
 
+def monotonic() -> float:
+    if not coordinates_stack:
+        result: float = _time_machine.original_monotonic()
+        return result
+    return coordinates_stack[-1].time()
+
+
+def monotonic_ns() -> int:
+    if not coordinates_stack:
+        result: int = _time_machine.original_monotonic_ns()
+        return result
+    return coordinates_stack[-1].time_ns()
+
+
 # pytest plugin
 
 if HAVE_PYTEST:  # pragma: no branch

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -249,21 +249,72 @@ def test_time_localtime_arg():
         assert local_time.tm_mday == 1
 
 
-def test_time_montonic():
+def test_time_monotonic():
+    last_time = time.monotonic()
+
+    def get_check_monotonic() -> float:
+        nonlocal last_time
+        new_time = time.monotonic()
+        assert new_time >= last_time
+        last_time = new_time
+        return new_time
+
     with time_machine.travel(EPOCH, tick=False) as t:
-        assert time.monotonic() == EPOCH
+        get_check_monotonic()
         t.shift(1)
-        assert time.monotonic() == EPOCH + 1
+        get_check_monotonic()
+
+    # check with tick
+    with time_machine.travel(EPOCH, tick=True) as t:
+        get_check_monotonic()
+        get_check_monotonic()
+
+    with time_machine.travel(EPOCH, tick=False) as t:
+        start_time = get_check_monotonic()
+        t.shift(1, affect_monotonic=True)
+        assert get_check_monotonic() - start_time == 1.
+
+        t.move_to(EPOCH_PLUS_ONE_YEAR, affect_monotonic=True)
+        assert get_check_monotonic() - start_time  == (
+            EPOCH_PLUS_ONE_YEAR_DATETIME - EPOCH_DATETIME).total_seconds()
+
+    # XXX: get_check_monotonic_ns() would fail here as we get back in time after
+    #      the time shifts
+
 
 
 def test_time_monotonic_ns():
+    last_time = time.monotonic_ns()
+
+    def get_check_monotonic_ns() -> int:
+        nonlocal last_time
+        new_time = time.monotonic_ns()
+        assert new_time >= last_time
+        last_time = new_time
+        return new_time
+
     with time_machine.travel(EPOCH, tick=False) as t:
-        assert time.monotonic_ns() == int(EPOCH * NANOSECONDS_PER_SECOND)
+        get_check_monotonic_ns()
         t.shift(1)
-        assert (
-            time.monotonic_ns()
-            == int(EPOCH * NANOSECONDS_PER_SECOND) + NANOSECONDS_PER_SECOND
-        )
+        get_check_monotonic_ns()
+
+    # check with ticks
+    with time_machine.travel(EPOCH, tick=True) as t:
+        get_check_monotonic_ns()
+        get_check_monotonic_ns()
+
+    with time_machine.travel(EPOCH, tick=False) as t:
+        start_time = get_check_monotonic_ns()
+        t.shift(1, affect_monotonic=True)
+        assert get_check_monotonic_ns() - start_time == NANOSECONDS_PER_SECOND
+
+        t.move_to(EPOCH_PLUS_ONE_YEAR, affect_monotonic=True)
+        assert get_check_monotonic_ns() - start_time == (
+                (EPOCH_PLUS_ONE_YEAR_DATETIME - EPOCH_DATETIME).total_seconds()
+                * NANOSECONDS_PER_SECOND)
+
+    # XXX: get_check_monotonic_ns() would fail here as we get back in time after
+    #      the time shifts
 
 
 def test_time_strftime_format():


### PR DESCRIPTION
With version 2.13 I noticed that all my tests using time-machine and asyncio were segfaulting. I have added an minimal example of such breaking at the end of this pr.

The cause of the segfault, was a post-module unload call from logging itself called from asyncio exception handler.
The obvious fix was to handle having an unloaded module from _time_machine_time and that is what's the first commit of the serie is about (fa9cc85521ff0cbb9a480885c026beb5bd0002a9).

However, the tests still fails after that (but they now complains about an unloaded module rather than crashing).

After a little bissect i found that the culprit commit was the one introduced in #382 : This commit replace monotonic by our custom time.time. This is problematic as many user of monotonic assumes that the returned value is, well, monotonic.

Having a non-monotonic `time.monotonic` is really problematic and does break a lot of use case. But even more, the Pr did not restore monotonic to it's pre-travel time after popping the coordinates, causing monotonic to be definitively wrong when travel was used once.

This restoration problem is fixed in the second commit (fa9d2eeef8c7c42b1fca697fd979eeaefa2caaa4).

The third commit of the serie (2e2e77b8b6579a712004dc7f00ee0f54a64340e6) force monotonic to start from the pre-travel monotonic (to avoid getting to pre-monotonic time or jumping from a the monotonic value to the time value (which are not in the same order at all). This is not an issue as the monotonic value should not hold any meaning, only the difference in value should have an impact. Monotonic still  only ticks when a time function is called. It is not fully accurate as it should ideally use the monotonic time as a ticking source and not the normal time, but as it will only break one second every year at most, it is an ok compromise until the way monotonic is handled is properly defined.

This leads us to another issue: since monotonic can only grow, any shift or move_to should not affect it further than the natural ticking time: Indeed, if we jump backward, monotonic will naturally break, but evan if we jump forward it will step back at the end of the travel time. 

The fourth commit (d8e361427036bc1dc7ac6b98d92c18f9883db86e) changes the current behavior and prevent those actions to affect monotonic unless an explicit affect_monotonic is passed (and the user is responsible for any subsequent breaking).

I think that ideally, monotonic may need to be handled completely differently than time.time, but this would require a lot more work and would need to add specific apis.

Below is a simple example triggering the mentionned crashes (should be run with pytest with the pytest-asyncio plugin):

```python
import asyncio
import datetime

import pytest
from time_machine import travel


pytest_plugins = ('pytest_asyncio',)

tasks = []

async def crash():
    tasks.append(asyncio.create_task(asyncio.sleep(100)))
    with travel(datetime.datetime.now() + datetime.timedelta(minutes=5)):
        pass
    assert False

@pytest.mark.asyncio
async def test_crash():
    task = await crash()

```

I believe this may fix the problems mentionned in #403 #393  and #387