### PR TITLE
Fix utcfromtimestamp() deprecation warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* Fix ``utcfromtimestamp()`` warning on Python 3.12+.
+
+  Thanks to Konstantin Baikov in `PR #424 <https://github.com/adamchainz/time-machine/pull/424>`__.
+
 * Avoid calling deprecated ``uuid._load_system_functions()`` on Python 3.9+.
 
   Thanks to Nikita Sobolev for the ping in `CPython Issue #113308 <https://github.com/python/cpython/issues/113308>`__.

--- a/src/time_machine/__init__.py
+++ b/src/time_machine/__init__.py
@@ -350,7 +350,7 @@ def utcnow() -> dt.datetime:
     if not coordinates_stack:
         result: dt.datetime = _time_machine.original_utcnow()
         return result
-    return dt.datetime.fromtimestamp(time(), dt.UTC)
+    return dt.datetime.fromtimestamp(time(), dt.timezone.utc).replace(tzinfo=None)
 
 
 # time module

--- a/src/time_machine/__init__.py
+++ b/src/time_machine/__init__.py
@@ -350,7 +350,7 @@ def utcnow() -> dt.datetime:
     if not coordinates_stack:
         result: dt.datetime = _time_machine.original_utcnow()
         return result
-    return dt.datetime.utcfromtimestamp(time())
+    return dt.datetime.fromtimestamp(time(), dt.UTC)
 
 
 # time module

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ commands =
       -W error::ResourceWarning \
       -W error::DeprecationWarning \
       -W error::PendingDeprecationWarning \
+      -W ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning \
       -W ignore:datetime.datetime.utcnow:DeprecationWarning \
       -m coverage run \
       -m pytest {posargs:tests}

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ commands =
       -W error::ResourceWarning \
       -W error::DeprecationWarning \
       -W error::PendingDeprecationWarning \
-      -W ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning \
       -W ignore:datetime.datetime.utcnow:DeprecationWarning \
       -m coverage run \
       -m pytest {posargs:tests}


### PR DESCRIPTION
In python 3.12 the following DeprecationWarning appears:

```
/time_machine/__init__.py:354: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
```

This commit fixes it and also removes the suppression from `tox.ini`