### PR TITLE
Fix segmentation fault when initializing travel with timedelta

### DIFF
--- a/src/time_machine/__init__.py
+++ b/src/time_machine/__init__.py
@@ -221,6 +221,7 @@ uuid_uuid_create_patcher = mock.patch.object(uuid, "_UuidCreate", new=None)
 
 class travel:
     def __init__(self, destination: DestinationType, *, tick: bool = True) -> None:
+        _time_machine.patch_if_needed()
         self.destination_timestamp, self.destination_tzname = extract_timestamp_tzname(
             destination
         )
@@ -228,9 +229,6 @@ class travel:
 
     def start(self) -> Coordinates:
         global coordinates_stack
-
-        _time_machine.patch_if_needed()
-
         if not coordinates_stack:
             if sys.version_info < (3, 9):
                 # We need to cause the functions to be loaded before we patch


### PR DESCRIPTION
The following Python script:

    from datetime import timedelta
    import time_machine
    with time_machine.travel(timedelta()):
        pass

crashes due to a segmentation fault in the constructor of the `travel` class.

The crash happens when the constructor tries to determine the destination timestamp like this:

    timestamp = time() + dest.total_seconds()

where `time()` calls `result = _time_machine.original_time()` which crashes if time_machine's patches are not applied yet and thus the `original_time` function pointer is still `NULL`.

This happens when trying to initialize `travel` with `timedelta` only when `travel` was not successfully used yet in the same process before. Those conditions are hard to meet in the test cases of this library so we fix the bug without adding a new test that would prove that the fix works.

Closes #431