### PR TITLE
Build wheels for Python 3.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,26 +13,26 @@ jobs:
     strategy:
       matrix:
         os:
-        - ubuntu-22.04
+        - ubuntu-24.04
         - windows-2022
-        - macos-12
+        - macos-14
 
     env:
       CIBW_ARCHS_LINUX: x86_64 i686 aarch64
       CIBW_ARCHS_MACOS: x86_64 universal2
       CIBW_ARCHS_WINDOWS: AMD64 x86 ARM64
-      CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*"
+      CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*-* cp313-*"
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.17.0
+          python -m pip install cibuildwheel==2.20.0
 
       - name: Set up QEMU
         if: runner.os == 'Linux'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* Include wheels for Python 3.13.
+
 2.14.2 (2024-06-29)
 -------------------
 


### PR DESCRIPTION
Also upgrade wheel build env:

* GitHub actions images: https://github.com/actions/runner-images
* Python
* cibuildwheel: https://github.com/pypa/cibuildwheel/releases/tag/v2.20.0