### PR TITLE
Downgrade wheel build environment Ubuntu version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os:
-        - ubuntu-24.04
+        - ubuntu-22.04
         - windows-2022
         - macos-14
 


### PR DESCRIPTION
PR #467 broke the build due to this bug: https://github.com/pypa/cibuildwheel/issues/1957 .

This time I’ll test the workflow *before* merging.