### PR TITLE
Fix CIBW_BUILD argument for Python 3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       CIBW_ARCHS_LINUX: x86_64 i686 aarch64
       CIBW_ARCHS_MACOS: x86_64 universal2
       CIBW_ARCHS_WINDOWS: AMD64 x86 ARM64
-      CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*-* cp313-*"
+      CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
I noticed the `-*-*` in the CIBW_BUILD for 3.12. Perhaps this could fix the missing wheels 3.12? 

Fixes #469.