### PR TITLE
Stop building Python 3.7 wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       CIBW_ARCHS_LINUX: x86_64 i686 aarch64
       CIBW_ARCHS_MACOS: x86_64 universal2
       CIBW_ARCHS_WINDOWS: AMD64 x86 ARM64
-      CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+      CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Missed in #364.