### PR TITLE
Support free-threaded Python

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,9 @@ jobs:
         - '3.11'
         - '3.12'
         - '3.13'
+        - '3.13t'
         - '3.14'
+        - '3.14t'
 
     steps:
     - uses: actions/checkout@v4

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,10 @@ Unreleased
 
   Thanks to Edgar Ramírez Mondragón in `PR #521 <https://github.com/adamchainz/time-machine/pull/521>`__.
 
+* Support free-threaded Python.
+
+  Thanks to Javier Buzzi in `PR #500 <https://github.com/adamchainz/time-machine/pull/500>`__.
+
 * Add a new CLI for migrating code from freezegun to time-machine.
 
   Install with ``pip install time-machine[cli]`` and run with ``python -m time_machine migrate``.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,7 +5,7 @@ Installation
 Requirements
 ------------
 
-Python 3.9 to 3.14 supported.
+Python 3.9 to 3.14 supported, including free-threaded variants from Python 3.13 onwards.
 
 Only CPython is supported at this time because time-machine directly hooks into the C-level API.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,20 @@ docs = [
 ]
 
 [tool.cibuildwheel]
-build = [ "cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*" ]
+build = [
+  "cp314-*",
+  "cp314t-*",
+  "cp313-*",
+  "cp313t-*",
+  "cp312-*",
+  "cp311-*",
+  "cp310-*",
+  "cp39-*",
+]
+enable = [
+  # Enable free-threaded wheels on Python 3.13 (where it was experimental)
+  "cpython-freethreading",
+]
 linux.archs = [ "x86_64", "i686", "aarch64" ]
 macos.archs = [ "x86_64", "universal2" ]
 windows.archs = [ "AMD64", "x86", "ARM64" ]

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 requires =
     tox>=4.2
 env_list =
-    py{314, 313, 312, 311, 310, 39}
+    py{314, 313, 312, 311, 310, 39, 314t, 313t}
 
 [testenv]
 runner = uv-venv-lock-runner


### PR DESCRIPTION
Looks good!

Had to remove the `uv pip install --system` because i kept getting this error in the threaded python versions:
```
error: The interpreter at /usr is externally managed, and indicates the following:

  To install Python packages system-wide, try apt install
  python3-xyz, where xyz is the package you are trying to
  install.

  If you wish to install a non-Debian-packaged Python package,
  create a virtual environment using python3 -m venv path/to/venv.
  Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
  sure you have python3-full installed.

  If you wish to install a non-Debian packaged Python application,
  it may be easiest to use pipx install xyz, which will manage a
  virtual environment for you. Make sure you have pipx installed.

  See /usr/share/doc/python3.12/README.venv for more information.

Consider creating a virtual environment with `uv venv`.
```
