### PR TITLE
Fix coverage measurement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ xfail_strict = true
 branch = true
 parallel = true
 source = [
-  "src/_time_machine.c",
+  "time_machine",
   "tests",
 ]
 


### PR DESCRIPTION
An error in 99a97b2513fcd6b02ac8838144938e2ab7b383be lead to only tests being measured for coverage. Luckily things stuck at 100% for the main source since then.