### PR TITLE
Move cibuildwheel configuration to pyproject.toml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,12 +115,6 @@ jobs:
         || 'unknown'
       }}
 
-    env:
-      CIBW_ARCHS_LINUX: x86_64 i686 aarch64
-      CIBW_ARCHS_MACOS: x86_64 universal2
-      CIBW_ARCHS_WINDOWS: AMD64 x86 ARM64
-      CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
-
     steps:
       - uses: actions/checkout@v4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,12 @@ docs = [
   "sphinx-copybutton>=0.5.2",
 ]
 
+[tool.cibuildwheel]
+build = [ "cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*" ]
+linux.archs = [ "x86_64", "i686", "aarch64" ]
+macos.archs = [ "x86_64", "universal2" ]
+windows.archs = [ "AMD64", "x86", "ARM64" ]
+
 [tool.ruff]
 lint.select = [
   # flake8-bugbear


### PR DESCRIPTION
This is the primary configuration source in the cibuildwheel documentation and it makes it easier to test locally.