### PR TITLE
Handle warnings better

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,14 @@ addopts = """\
     --strict-markers
     """
 xfail_strict = true
+filterwarnings = [
+  "error",
+  "error::ResourceWarning",
+  "error::DeprecationWarning",
+  "error::PendingDeprecationWarning",
+  "ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning",
+  "ignore:datetime.datetime.utcnow:DeprecationWarning",
+]
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,14 +132,6 @@ addopts = """\
     --strict-markers
     """
 xfail_strict = true
-filterwarnings = [
-  "error",
-  "error::ResourceWarning",
-  "error::DeprecationWarning",
-  "error::PendingDeprecationWarning",
-  "ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning",
-  "ignore:datetime.datetime.utcnow:DeprecationWarning",
-]
 
 [tool.coverage.run]
 branch = true

--- a/tox.ini
+++ b/tox.ini
@@ -12,13 +12,6 @@ extras =
 set_env =
     PYTHONDEVMODE = 1
 commands =
-    python \
-      -W error::ResourceWarning \
-      -W error::DeprecationWarning \
-      -W error::PendingDeprecationWarning \
-      -W ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning \
-      -W ignore:datetime.datetime.utcnow:DeprecationWarning \
-      -m coverage run \
-      -m pytest {posargs:tests}
+    python -m coverage run -m pytest {posargs:tests}
 dependency_groups =
     test

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,14 @@ extras =
 set_env =
     PYTHONDEVMODE = 1
 commands =
-    python -m coverage run -m pytest {posargs:tests}
+    python \
+      -W error \
+      -W error::ResourceWarning \
+      -W error::DeprecationWarning \
+      -W error::PendingDeprecationWarning \
+      -W ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning \
+      -W ignore:datetime.datetime.utcnow:DeprecationWarning \
+      -m coverage run \
+      -m pytest {posargs:tests}
 dependency_groups =
     test


### PR DESCRIPTION
Depends on: https://github.com/adamchainz/time-machine/pull/536
----
[The warning for the GIL](https://github.com/adamchainz/time-machine/pull/536) was not noticed because warnings are not failing, and are not in your face.

This change does 2 things:
* ~moves the warnings down to pyproject so everyone running `pytest` notices the issue~
* makes all unknown warnings fail so we can catch them faster in CI