### PR TITLE
Enable more compiler warnings and fix results

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,4 +11,25 @@ if hasattr(sys, "pypy_version_info"):
     )
 
 
-setup(ext_modules=[Extension(name="_time_machine", sources=["src/_time_machine.c"])])
+setup(
+    ext_modules=[
+        Extension(
+            name="_time_machine",
+            sources=["src/_time_machine.c"],
+            extra_compile_args=[
+                "-Wall",
+                "-Wextra",
+                "-Werror",
+                "-Wstrict-prototypes",
+                "-Wmissing-prototypes",
+                "-Wunused",
+                "-Wuninitialized",
+                "-Wshadow",
+                "-Wformat=2",
+                "-Wformat-security",
+                "-Wno-unused-parameter",
+                "-Wno-missing-field-initializers",
+            ],
+        )
+    ]
+)

--- a/src/_time_machine.c
+++ b/src/_time_machine.c
@@ -2,6 +2,10 @@
 #include <limits.h>
 #include <stdlib.h>
 
+// Forward declarations
+PyMODINIT_FUNC
+PyInit__time_machine(void);
+
 // Module state
 typedef struct {
 #if PY_VERSION_HEX >= 0x030d00a4
@@ -516,11 +520,13 @@ _time_machine_patch_if_needed(PyObject *module, PyObject *unused)
     PyCFunctionObject *datetime_datetime_now =
         (PyCFunctionObject *)PyObject_GetAttrString(datetime_class, "now");
 #if PY_VERSION_HEX >= 0x030d00a4
-    state->original_now = (PyCFunctionFastWithKeywords)datetime_datetime_now->m_ml->ml_meth;
+    state->original_now =
+        (PyCFunctionFastWithKeywords)(void (*)(void))datetime_datetime_now->m_ml->ml_meth;
 #else
-    state->original_now = (_PyCFunctionFastWithKeywords)datetime_datetime_now->m_ml->ml_meth;
+    state->original_now =
+        (_PyCFunctionFastWithKeywords)(void (*)(void))datetime_datetime_now->m_ml->ml_meth;
 #endif
-    datetime_datetime_now->m_ml->ml_meth = (PyCFunction)_time_machine_now;
+    datetime_datetime_now->m_ml->ml_meth = (PyCFunction)(void (*)(void))_time_machine_now;
     Py_DECREF(datetime_datetime_now);
 
     PyCFunctionObject *datetime_datetime_utcnow =
@@ -617,7 +623,7 @@ PyDoc_STRVAR(module_doc, "_time_machine module");
 
 static PyMethodDef module_functions[] = {
     {"original_now",
-        (PyCFunction)_time_machine_original_now,
+        (PyCFunction)(void (*)(void))_time_machine_original_now,
         METH_FASTCALL | METH_KEYWORDS,
         original_now_doc},
     {"original_utcnow",


### PR DESCRIPTION
Add some basic flags compatible with gcc and clang, and fix the resulting errors:

```
src/_time_machine.c:519:27: error: cast from 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') to 'PyCFunctionFastWithKeywords' (aka 'struct _object
*(*)(struct _object *, struct _object *const *, long, struct _object *)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
  519 |     state->original_now = (PyCFunctionFastWithKeywords)datetime_datetime_now->m_ml->ml_meth;
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/_time_machine.c:523:44: error: cast from 'PyObject *(*)(PyTypeObject *, PyObject *const *, Py_ssize_t, PyObject *)' (aka 'struct _object *(*)(struct _typeobject *,
struct _object *const *, long, struct _object *)') to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type
[-Werror,-Wcast-function-type-mismatch]
  523 |     datetime_datetime_now->m_ml->ml_meth = (PyCFunction)_time_machine_now;
      |                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/_time_machine.c:620:9: error: cast from 'PyObject *(*)(PyObject *, PyObject *const *, Py_ssize_t, PyObject *)' (aka 'struct _object *(*)(struct _object *, struct
_object *const *, long, struct _object *)') to 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') converts to incompatible function type
[-Werror,-Wcast-function-type-mismatch]
  620 |         (PyCFunction)_time_machine_original_now,
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/_time_machine.c:697:1: error: no previous prototype for function 'PyInit__time_machine' [-Werror,-Wmissing-prototypes]
  697 | PyInit__time_machine(void)
      | ^
src/_time_machine.c:696:1: note: declare 'static' if the function is not intended to be used outside of this translation unit
  696 | PyMODINIT_FUNC
      | ^
/Users/chainz/.local/share/uv/python/cpython-3.13.6-macos-aarch64-none/include/python3.13/exports.h:103:58: note: expanded from macro 'PyMODINIT_FUNC'
  103 | #               define PyMODINIT_FUNC Py_EXPORTED_SYMBOL PyObject*
      |                                                          ^
4 errors generated.
error: command '/usr/bin/cc' failed with exit code 1
```