### PR TITLE
Added support for common.time and other rippling usages

### DIFF
--- a/src/time_machine/cli.py
+++ b/src/time_machine/cli.py
@@ -493,9 +493,7 @@ def remove_keyword(tokens: list[Token], i: int, node: ast.keyword) -> None:
     # Find the NAME token for the keyword arg to the left of the value
     arg_name = getattr(node, "arg", None)
     k = i
-    while k > 0 and not (
-        tokens[k].name == "NAME" and tokens[k].src == arg_name
-    ):
+    while k > 0 and not (tokens[k].name == "NAME" and tokens[k].src == arg_name):
         k -= 1
 
     # Compute removal bounds


### PR DESCRIPTION
Example of modifying CLI for rippling use cases.

Does the following:
- Added support for `common.time` wrapper
- Ignore kwargs like `tz` and `auto_tick_seconds`
- Allow more nested type of imports
  ```python
                    if len(node.names) == 1:
                        ret[ast_start_offset(node)].append(
                            partial(replace_import_from, node=node)
                        )
                    else:
                        ret[ast_start_offset(node)].append(
                            partial(replace_import_from_multi, node=node)
                        )
   ```