### PR TITLE
Import more once in C extension

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+* Import date and time functions once in the C extension.
+
+  This should improve speed a little bit, and avoid segmentation faults when the functions have been swapped out, such as when freezegun is in effect.
+  (time-machine still won’t apply if freezegun is in effect.)
+
 2.18.0 (2025-08-18)
 -------------------
 


### PR DESCRIPTION
Following #553, move all the other imports in the C extenion to only be done once:

* datetime class
* datetime.datetime.now
* datetime.datetime.utcnow
* time.clock_gettime
* time.clock_gettime_ns
* time.gmtime
* time.localtime
* time.monotonic
* time.monotonic_ns
* time.strftime
* time.time
* time.time_ns

Fixes #531 .