### PR TITLE
Drop py39 environment from tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 requires =
     tox>=4.2
 env_list =
-    py{314, 313, 312, 311, 310, 39, 314t, 313t}
+    py{314, 313, 312, 311, 310, 314t, 313t}
 
 [testenv]
 runner = uv-venv-lock-runner


### PR DESCRIPTION
Regex edit in #572 missed this case.