### PR TITLE
Remove Python 3.9 from cibuildwheel target list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ build = [
   "cp312-*",
   "cp311-*",
   "cp310-*",
-  "cp39-*",
 ]
 enable = [
   # Enable free-threaded wheels on Python 3.13 (where it was experimental)


### PR DESCRIPTION
Missed in #572.