### PR TITLE
Change freezegun detection

### DIFF
--- a/src/time_machine/__init__.py
+++ b/src/time_machine/__init__.py
@@ -269,13 +269,8 @@ class travel:
         self.tick = tick
 
     def start(self) -> Traveller:
-        if "freezegun" in sys.modules:  # pragma: no branch
-            from freezegun.api import freeze_factories
-
-            if freeze_factories:
-                raise RuntimeError(
-                    "time-machine cannot start when freezegun is active."
-                )
+        if "freezegun" in sys.modules and dt.datetime.__name__ == "FakeDatetime":
+            raise RuntimeError("time-machine cannot start when freezegun is active.")
 
         if not traveller_stack:
             _time_machine.patch()


### PR DESCRIPTION
Move from importing `freeze_factories` to checking if `dt.datetime` has been swapped to `FakeDatetime`. This method will work even for older freezegun versions that don't have `freeze_factories`.