### PR TITLE
Stop shipping wheels for 32-bit Linux and Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,8 +105,6 @@ jobs:
         - os: linux
           arch: aarch64
         - os: linux
-          arch: i686
-        - os: linux
           arch: x86_64
         - os: macos
           arch: arm64
@@ -114,14 +112,11 @@ jobs:
           arch: x86_64
         - os: windows
           arch: AMD64
-        - os: windows
-          arch: x86
-        - os: windows
-          arch: ARM64
 
     runs-on:
       ${{
-        (matrix.os == 'linux' && 'ubuntu-24.04')
+        (matrix.os == 'linux' && matrix.arch == 'aarch64' && 'ubuntu-24.04-arm')
+        || (matrix.os == 'linux' && 'ubuntu-24.04')
         || (matrix.os == 'macos' && matrix.arch == 'arm64' && 'macos-15')
         || (matrix.os == 'macos' && matrix.arch == 'x86_64' && 'macos-15-intel')
         || (matrix.os == 'windows' && 'windows-2022')
@@ -132,12 +127,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: astral-sh/setup-uv@v7
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        if: matrix.os == 'linux'
-        with:
-          platforms: all
 
       - name: Build sdist
         if: matrix.os == 'linux' && matrix.arch == 'x86_64'

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* Stop shipping wheels for 32-bit Linux and Windows.
+
+  `PR #605 <https://github.com/adamchainz/time-machine/pull/605>`__.
+
 3.2.0 (2025-12-17)
 ------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ build = { requires-python = ">=3.14" }
 sphinx-build-compatibility = { git = "https://github.com/readthedocs/sphinx-build-compatibility", rev = "4f304bd4562cdc96316f4fec82b264ca379d23e0" }
 
 [tool.cibuildwheel]
+archs = [ "auto64" ]
 build = [
   "cp314-*",
   "cp314t-*",


### PR DESCRIPTION
These wheels seem to be basically unused, since the platforms are so old at this point.

I checked the [PyPI Bigquery stats](https://docs.pypi.org/api/bigquery/) with several queries, including:

```sql
SELECT
  CASE
    WHEN file.filename LIKE '%i686%' OR file.filename LIKE '%win32%' THEN 'i686/32-bit'
    WHEN file.filename LIKE '%x86_64%' OR file.filename LIKE '%amd64%' OR file.filename LIKE '%win_amd64%' THEN 'x86_64/64-bit'
    WHEN file.filename LIKE '%aarch64%' OR file.filename LIKE '%arm64%' THEN 'ARM64'
    WHEN file.filename LIKE '%.whl' THEN 'other-arch'
    ELSE 'source/unknown'
  END as architecture,
  COUNT(*) as downloads,
  ROUND(COUNT(*) * 100.0 / SUM(COUNT(*)) OVER (), 2) as percentage
FROM `bigquery-public-data.pypi.file_downloads`
WHERE
  project = 'time-machine'
  AND DATE(timestamp) BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY) AND CURRENT_DATE()
GROUP BY architecture
ORDER BY downloads DESC
```

This one reported ~0.12% of downloads for 32 bit, but since many different wheels for one version were downloaded exactly 173 times, it seems likely these came from "grab-it-all" bots/mirrors, rather than real users.

Also, [cibuildwheel's `archs` option](https://cibuildwheel.pypa.io/en/stable/options/#archs) removed 32-bit builds on Linux for `auto` already and will do so for Windows at some point. `auto64` opts into removing it now.

On the way, switch Linux ARM builds from QEMU to [ARM's provided runner images](https://github.com/actions/partner-runner-images).