### PR TITLE
Mock `datetime.date.today()` directly

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+* Mock ``datetime.date.today()`` directly, for Python 3.15 support.
+
+  Previously time-machine was mocked only indirectly, since CPython implemented it by calling ``cls.fromtimestamp(time.time())``.
+  Python 3.15 added a fast path that reads the system clock directly (`CPython Issue #130980 <https://github.com/python/cpython/pull/130980>`__), so time travel no longer affected it, which the new mock fixes.
+  Consequently, there are new :ref:`escape hatch <escape-hatch>` functions: ``escape_hatch.datetime.date.today()`` and ``escape_hatch.datetime.datetime.today()``.
+
+  Thanks to Miro Hrončok and Karolina Surma for the report in `Issue #610 <https://github.com/adamchainz/time-machine/issues/610>`__, Lumír 'Frenzy' Balhar for the fix in `PR #618 <https://github.com/adamchainz/time-machine/pull/618>`__, and Maurycy Pawłowski-Wieroński for review
+
 * Build with frame pointers enabled, preparation for `PEP 831 <https://peps.python.org/pep-0831/>`__.
 
   `PR #627 <https://github.com/adamchainz/time-machine/issues/627>`__.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -373,9 +373,17 @@ The functions are:
 
   Returns ``True`` if ``time_machine.travel()`` is active, ``False`` otherwise.
 
+* ``escape_hatch.datetime.date.today()``
+
+  Wraps the real ``datetime.date.today()``.
+
 * ``escape_hatch.datetime.datetime.now()``
 
   Wraps the real ``datetime.datetime.now()``.
+
+* ``escape_hatch.datetime.datetime.today()``
+
+  Wraps the real ``datetime.datetime.today()``.
 
 * ``escape_hatch.datetime.datetime.utcnow()``
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -357,6 +357,8 @@ Main API
           with time_machine.travel(...):
               ...
 
+.. _escape-hatch:
+
 Escape hatch API
 ================
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -89,7 +89,9 @@ Main API
 
   All datetime functions in the standard library are mocked to move to the destination current datetime:
 
+  * ``datetime.date.today()``
   * ``datetime.datetime.now()``
+  * ``datetime.datetime.today()``
   * ``datetime.datetime.utcnow()``
   * ``time.clock_gettime()`` (only for ``CLOCK_REALTIME``)
   * ``time.clock_gettime_ns()`` (only for ``CLOCK_REALTIME``)

--- a/src/_time_machine.c
+++ b/src/_time_machine.c
@@ -8,8 +8,10 @@ typedef struct {
     PyObject *datetime_module;
     PyObject *time_module;
     PyObject *datetime_class;
+    PyObject *date_class;
     PyCFunctionObject *datetime_datetime_now;
     PyCFunctionObject *datetime_datetime_utcnow;
+    PyCFunctionObject *date_today;
     PyCFunctionObject *time_clock_gettime;
     PyCFunctionObject *time_clock_gettime_ns;
     PyCFunctionObject *time_gmtime;
@@ -24,6 +26,8 @@ typedef struct {
     _PyCFunctionFastWithKeywords original_now;
 #endif
     PyCFunction original_utcnow;
+    PyCFunction original_date_today;
+    PyCFunction original_datetime_today;
     PyCFunction original_clock_gettime;
     PyCFunction original_clock_gettime_ns;
     PyCFunction original_gmtime;
@@ -129,6 +133,96 @@ PyDoc_STRVAR(original_utcnow_doc,
     "original_utcnow() -> datetime\n\
 \n\
 Call datetime.datetime.utcnow() after patching.");
+
+/* datetime.date.today() and datetime.datetime.today()
+ * Note: datetime.datetime doesn't define its own today(), it inherits from date.
+ * So we patch date.today() with a wrapper that checks the calling class type.
+ */
+
+static PyObject *
+_time_machine_today(PyObject *cls, PyObject *args)
+{
+    PyObject *time_machine_module = PyImport_ImportModule("time_machine");
+    if (time_machine_module == NULL) {
+        return NULL;  // Propagate ImportError
+    }
+    PyObject *datetime_module = PyImport_ImportModule("datetime");
+    if (datetime_module == NULL) {
+        Py_DECREF(time_machine_module);
+        return NULL;  // Propagate ImportError
+    }
+    PyObject *datetime_class = PyObject_GetAttrString(datetime_module, "datetime");
+    if (datetime_class == NULL) {
+        Py_DECREF(datetime_module);
+        Py_DECREF(time_machine_module);
+        return NULL;  // Propagate AttributeError
+    }
+
+    /* Check if cls is datetime.datetime (or subclass) vs just date */
+    int is_datetime = PyObject_IsSubclass(cls, datetime_class);
+    if (is_datetime == -1) {
+        Py_DECREF(datetime_class);
+        Py_DECREF(datetime_module);
+        Py_DECREF(time_machine_module);
+        return NULL;  // Propagate error
+    }
+
+    const char *func_name = (is_datetime == 1) ? "datetime_today" : "date_today";
+    PyObject *time_machine_func = PyObject_GetAttrString(time_machine_module, func_name);
+    if (time_machine_func == NULL) {
+        Py_DECREF(datetime_class);
+        Py_DECREF(datetime_module);
+        Py_DECREF(time_machine_module);
+        return NULL;  // Propagate AttributeError
+    }
+
+    PyObject *result = PyObject_CallObject(time_machine_func, args);
+
+    Py_DECREF(time_machine_func);
+    Py_DECREF(datetime_class);
+    Py_DECREF(datetime_module);
+    Py_DECREF(time_machine_module);
+
+    return result;
+}
+
+static PyObject *
+_time_machine_original_date_today(PyObject *module, PyObject *args)
+{
+    _time_machine_state *state = get_time_machine_state(module);
+
+    if (state->original_date_today == NULL) {
+        PyErr_SetString(PyExc_ValueError, "Not currently time-travelling.");
+        return NULL;
+    }
+
+    PyObject *result = state->original_date_today(state->date_class, args);
+
+    return result;
+}
+PyDoc_STRVAR(original_date_today_doc,
+    "original_date_today() -> date\n\
+\n\
+Call datetime.date.today() after patching.");
+
+static PyObject *
+_time_machine_original_datetime_today(PyObject *module, PyObject *args)
+{
+    _time_machine_state *state = get_time_machine_state(module);
+
+    if (state->original_datetime_today == NULL) {
+        PyErr_SetString(PyExc_ValueError, "Not currently time-travelling.");
+        return NULL;
+    }
+
+    PyObject *result = state->original_datetime_today(state->datetime_class, args);
+
+    return result;
+}
+PyDoc_STRVAR(original_datetime_today_doc,
+    "original_datetime_today() -> datetime\n\
+\n\
+Call datetime.datetime.today() after patching.");
 
 /* time.clock_gettime() */
 
@@ -458,6 +552,15 @@ _time_machine_patch(PyObject *module, PyObject *unused)
     state->original_utcnow = state->datetime_datetime_utcnow->m_ml->ml_meth;
     state->datetime_datetime_utcnow->m_ml->ml_meth = _time_machine_utcnow;
 
+    /* Patch today() - since datetime.datetime.today() inherits from date.today(),
+     * we only need to patch date.today() once. Save both originals first for
+     * the escape hatch, then patch with a unified wrapper that dispatches based
+     * on the calling class type.
+     */
+    state->original_date_today = state->date_today->m_ml->ml_meth;
+    state->original_datetime_today = state->date_today->m_ml->ml_meth;
+    state->date_today->m_ml->ml_meth = _time_machine_today;
+
     /*
         time.clock_gettime(), only available on Unix platforms.
     */
@@ -517,6 +620,10 @@ _time_machine_unpatch(PyObject *module, PyObject *unused)
     state->datetime_datetime_utcnow->m_ml->ml_meth = state->original_utcnow;
     state->original_utcnow = NULL;
 
+    state->date_today->m_ml->ml_meth = state->original_date_today;
+    state->original_date_today = NULL;
+    state->original_datetime_today = NULL;
+
     /*
         time.clock_gettime(), only available on Unix platforms.
     */
@@ -566,6 +673,14 @@ static PyMethodDef module_functions[] = {
         (PyCFunction)_time_machine_original_utcnow,
         METH_NOARGS,
         original_utcnow_doc},
+    {"original_date_today",
+        (PyCFunction)_time_machine_original_date_today,
+        METH_NOARGS,
+        original_date_today_doc},
+    {"original_datetime_today",
+        (PyCFunction)_time_machine_original_datetime_today,
+        METH_NOARGS,
+        original_datetime_today_doc},
 #if PY_VERSION_HEX >= 0x030d00a2
     {"original_clock_gettime",
         (PyCFunction)_time_machine_original_clock_gettime,
@@ -637,6 +752,17 @@ _time_machine_exec(PyObject *module)
         goto error;
     }
 
+    state->date_class = PyObject_GetAttrString(state->datetime_module, "date");
+    if (state->date_class == NULL) {
+        goto error;
+    }
+
+    state->date_today =
+        (PyCFunctionObject *)PyObject_GetAttrString(state->date_class, "today");
+    if (state->date_today == NULL) {
+        goto error;
+    }
+
     state->time_module = PyImport_ImportModule("time");
     if (state->time_module == NULL) {
         goto error;
@@ -700,8 +826,10 @@ _time_machine_exec(PyObject *module)
 error:
     Py_CLEAR(state->datetime_module);
     Py_CLEAR(state->datetime_class);
+    Py_CLEAR(state->date_class);
     Py_CLEAR(state->datetime_datetime_now);
     Py_CLEAR(state->datetime_datetime_utcnow);
+    Py_CLEAR(state->date_today);
     Py_CLEAR(state->time_module);
     Py_CLEAR(state->time_clock_gettime);
     Py_CLEAR(state->time_clock_gettime_ns);
@@ -719,8 +847,10 @@ _time_machine_traverse(PyObject *module, visitproc visit, void *arg)
     _time_machine_state *state = get_time_machine_state(module);
     Py_VISIT(state->datetime_module);
     Py_VISIT(state->datetime_class);
+    Py_VISIT(state->date_class);
     Py_VISIT(state->datetime_datetime_now);
     Py_VISIT(state->datetime_datetime_utcnow);
+    Py_VISIT(state->date_today);
     Py_VISIT(state->time_module);
     Py_VISIT(state->time_clock_gettime);
     Py_VISIT(state->time_clock_gettime_ns);
@@ -738,8 +868,10 @@ _time_machine_clear(PyObject *module)
     _time_machine_state *state = get_time_machine_state(module);
     Py_CLEAR(state->datetime_module);
     Py_CLEAR(state->datetime_class);
+    Py_CLEAR(state->date_class);
     Py_CLEAR(state->datetime_datetime_now);
     Py_CLEAR(state->datetime_datetime_utcnow);
+    Py_CLEAR(state->date_today);
     Py_CLEAR(state->time_module);
     Py_CLEAR(state->time_clock_gettime);
     Py_CLEAR(state->time_clock_gettime_ns);

--- a/src/_time_machine.c
+++ b/src/_time_machine.c
@@ -8,7 +8,6 @@ typedef struct {
     PyObject *datetime_module;
     PyObject *time_module;
     PyObject *datetime_class;
-    PyObject *date_class;
     PyCFunctionObject *datetime_datetime_now;
     PyCFunctionObject *datetime_datetime_utcnow;
     PyCFunctionObject *date_today;
@@ -27,7 +26,6 @@ typedef struct {
 #endif
     PyCFunction original_utcnow;
     PyCFunction original_date_today;
-    PyCFunction original_datetime_today;
     PyCFunction original_clock_gettime;
     PyCFunction original_clock_gettime_ns;
     PyCFunction original_gmtime;
@@ -136,7 +134,8 @@ Call datetime.datetime.utcnow() after patching.");
 
 /* datetime.date.today() and datetime.datetime.today()
  * Note: datetime.datetime doesn't define its own today(), it inherits from date.
- * So we patch date.today() with a wrapper that checks the calling class type.
+ * So we patch date.today() with a wrapper that calls cls.fromtimestamp(), which
+ * returns the right type for date, datetime, and subclasses of either.
  */
 
 static PyObject *
@@ -146,83 +145,19 @@ _time_machine_today(PyObject *cls, PyObject *args)
     if (time_machine_module == NULL) {
         return NULL;  // Propagate ImportError
     }
-    PyObject *datetime_module = PyImport_ImportModule("datetime");
-    if (datetime_module == NULL) {
-        Py_DECREF(time_machine_module);
-        return NULL;  // Propagate ImportError
-    }
-    PyObject *datetime_class = PyObject_GetAttrString(datetime_module, "datetime");
-    if (datetime_class == NULL) {
-        Py_DECREF(datetime_module);
-        Py_DECREF(time_machine_module);
-        return NULL;  // Propagate AttributeError
-    }
 
-    /* Check if cls is datetime.datetime (or subclass) vs just date */
-    int is_datetime = PyObject_IsSubclass(cls, datetime_class);
-    if (is_datetime == -1) {
-        Py_DECREF(datetime_class);
-        Py_DECREF(datetime_module);
-        Py_DECREF(time_machine_module);
-        return NULL;  // Propagate error
-    }
-
-    const char *func_name = (is_datetime == 1) ? "datetime_today" : "date_today";
-    PyObject *time_machine_func = PyObject_GetAttrString(time_machine_module, func_name);
-    if (time_machine_func == NULL) {
-        Py_DECREF(datetime_class);
-        Py_DECREF(datetime_module);
-        Py_DECREF(time_machine_module);
-        return NULL;  // Propagate AttributeError
-    }
-
-    PyObject *result = PyObject_CallObject(time_machine_func, args);
-
-    Py_DECREF(time_machine_func);
-    Py_DECREF(datetime_class);
-    Py_DECREF(datetime_module);
+    PyObject *timestamp = PyObject_CallMethod(time_machine_module, "time", NULL);
     Py_DECREF(time_machine_module);
-
-    return result;
-}
-
-static PyObject *
-_time_machine_original_date_today(PyObject *module, PyObject *args)
-{
-    _time_machine_state *state = get_time_machine_state(module);
-
-    if (state->original_date_today == NULL) {
-        PyErr_SetString(PyExc_ValueError, "Not currently time-travelling.");
+    if (timestamp == NULL) {
         return NULL;
     }
 
-    PyObject *result = state->original_date_today(state->date_class, args);
+    PyObject *result = PyObject_CallMethod(cls, "fromtimestamp", "O", timestamp);
+
+    Py_DECREF(timestamp);
 
     return result;
 }
-PyDoc_STRVAR(original_date_today_doc,
-    "original_date_today() -> date\n\
-\n\
-Call datetime.date.today() after patching.");
-
-static PyObject *
-_time_machine_original_datetime_today(PyObject *module, PyObject *args)
-{
-    _time_machine_state *state = get_time_machine_state(module);
-
-    if (state->original_datetime_today == NULL) {
-        PyErr_SetString(PyExc_ValueError, "Not currently time-travelling.");
-        return NULL;
-    }
-
-    PyObject *result = state->original_datetime_today(state->datetime_class, args);
-
-    return result;
-}
-PyDoc_STRVAR(original_datetime_today_doc,
-    "original_datetime_today() -> datetime\n\
-\n\
-Call datetime.datetime.today() after patching.");
 
 /* time.clock_gettime() */
 
@@ -540,6 +475,9 @@ _time_machine_patch(PyObject *module, PyObject *unused)
     if (state->original_time)
         Py_RETURN_NONE;
 
+    state->original_date_today = state->date_today->m_ml->ml_meth;
+    state->date_today->m_ml->ml_meth = _time_machine_today;
+
 #if PY_VERSION_HEX >= 0x030d00a4
     state->original_now =
         (PyCFunctionFastWithKeywords)state->datetime_datetime_now->m_ml->ml_meth;
@@ -551,15 +489,6 @@ _time_machine_patch(PyObject *module, PyObject *unused)
 
     state->original_utcnow = state->datetime_datetime_utcnow->m_ml->ml_meth;
     state->datetime_datetime_utcnow->m_ml->ml_meth = _time_machine_utcnow;
-
-    /* Patch today() - since datetime.datetime.today() inherits from date.today(),
-     * we only need to patch date.today() once. Save both originals first for
-     * the escape hatch, then patch with a unified wrapper that dispatches based
-     * on the calling class type.
-     */
-    state->original_date_today = state->date_today->m_ml->ml_meth;
-    state->original_datetime_today = state->date_today->m_ml->ml_meth;
-    state->date_today->m_ml->ml_meth = _time_machine_today;
 
     /*
         time.clock_gettime(), only available on Unix platforms.
@@ -622,7 +551,6 @@ _time_machine_unpatch(PyObject *module, PyObject *unused)
 
     state->date_today->m_ml->ml_meth = state->original_date_today;
     state->original_date_today = NULL;
-    state->original_datetime_today = NULL;
 
     /*
         time.clock_gettime(), only available on Unix platforms.
@@ -673,14 +601,6 @@ static PyMethodDef module_functions[] = {
         (PyCFunction)_time_machine_original_utcnow,
         METH_NOARGS,
         original_utcnow_doc},
-    {"original_date_today",
-        (PyCFunction)_time_machine_original_date_today,
-        METH_NOARGS,
-        original_date_today_doc},
-    {"original_datetime_today",
-        (PyCFunction)_time_machine_original_datetime_today,
-        METH_NOARGS,
-        original_datetime_today_doc},
 #if PY_VERSION_HEX >= 0x030d00a2
     {"original_clock_gettime",
         (PyCFunction)_time_machine_original_clock_gettime,
@@ -752,13 +672,13 @@ _time_machine_exec(PyObject *module)
         goto error;
     }
 
-    state->date_class = PyObject_GetAttrString(state->datetime_module, "date");
-    if (state->date_class == NULL) {
+    PyObject *date_class = PyObject_GetAttrString(state->datetime_module, "date");
+    if (date_class == NULL) {
         goto error;
     }
 
-    state->date_today =
-        (PyCFunctionObject *)PyObject_GetAttrString(state->date_class, "today");
+    state->date_today = (PyCFunctionObject *)PyObject_GetAttrString(date_class, "today");
+    Py_DECREF(date_class);
     if (state->date_today == NULL) {
         goto error;
     }
@@ -826,7 +746,6 @@ _time_machine_exec(PyObject *module)
 error:
     Py_CLEAR(state->datetime_module);
     Py_CLEAR(state->datetime_class);
-    Py_CLEAR(state->date_class);
     Py_CLEAR(state->datetime_datetime_now);
     Py_CLEAR(state->datetime_datetime_utcnow);
     Py_CLEAR(state->date_today);
@@ -847,7 +766,6 @@ _time_machine_traverse(PyObject *module, visitproc visit, void *arg)
     _time_machine_state *state = get_time_machine_state(module);
     Py_VISIT(state->datetime_module);
     Py_VISIT(state->datetime_class);
-    Py_VISIT(state->date_class);
     Py_VISIT(state->datetime_datetime_now);
     Py_VISIT(state->datetime_datetime_utcnow);
     Py_VISIT(state->date_today);
@@ -868,7 +786,6 @@ _time_machine_clear(PyObject *module)
     _time_machine_state *state = get_time_machine_state(module);
     Py_CLEAR(state->datetime_module);
     Py_CLEAR(state->datetime_class);
-    Py_CLEAR(state->date_class);
     Py_CLEAR(state->datetime_datetime_now);
     Py_CLEAR(state->datetime_datetime_utcnow);
     Py_CLEAR(state->date_today);

--- a/src/time_machine/__init__.py
+++ b/src/time_machine/__init__.py
@@ -413,6 +413,16 @@ def utcnow() -> dt.datetime:
     return dt.datetime.fromtimestamp(time(), dt.timezone.utc).replace(tzinfo=None)
 
 
+def date_today() -> dt.date:
+    # Convert timestamp to date in local timezone
+    return dt.datetime.fromtimestamp(time()).date()
+
+
+def datetime_today() -> dt.datetime:
+    # Convert timestamp to datetime in local timezone
+    return dt.datetime.fromtimestamp(time())
+
+
 # time module
 
 
@@ -544,10 +554,21 @@ class _EscapeHatchDatetimeDatetime:
         result: dt.datetime = _time_machine.original_utcnow()
         return result
 
+    def today(self) -> dt.datetime:
+        result: dt.datetime = _time_machine.original_datetime_today()
+        return result
+
+
+class _EscapeHatchDatetimeDate:
+    def today(self) -> dt.date:
+        result: dt.date = _time_machine.original_date_today()
+        return result
+
 
 class _EscapeHatchDatetime:
     def __init__(self) -> None:
         self.datetime = _EscapeHatchDatetimeDatetime()
+        self.date = _EscapeHatchDatetimeDate()
 
 
 class _EscapeHatchTime:

--- a/src/time_machine/__init__.py
+++ b/src/time_machine/__init__.py
@@ -545,30 +545,30 @@ if HAVE_PYTEST:  # pragma: no branch
 # escape hatch
 
 
-class _EscapeHatchDatetimeDatetime:
-    def now(self, tz: dt.tzinfo | None = None) -> dt.datetime:
-        result: dt.datetime = _time_machine.original_now(tz)
-        return result
-
-    def utcnow(self) -> dt.datetime:
-        result: dt.datetime = _time_machine.original_utcnow()
-        return result
-
-    def today(self) -> dt.datetime:
-        result: dt.datetime = _time_machine.original_datetime_today()
-        return result
-
-
 class _EscapeHatchDatetimeDate:
     def today(self) -> dt.date:
         result: dt.date = _time_machine.original_date_today()
         return result
 
 
+class _EscapeHatchDatetimeDatetime:
+    def now(self, tz: dt.tzinfo | None = None) -> dt.datetime:
+        result: dt.datetime = _time_machine.original_now(tz)
+        return result
+
+    def today(self) -> dt.datetime:
+        result: dt.datetime = _time_machine.original_datetime_today()
+        return result
+
+    def utcnow(self) -> dt.datetime:
+        result: dt.datetime = _time_machine.original_utcnow()
+        return result
+
+
 class _EscapeHatchDatetime:
     def __init__(self) -> None:
-        self.datetime = _EscapeHatchDatetimeDatetime()
         self.date = _EscapeHatchDatetimeDate()
+        self.datetime = _EscapeHatchDatetimeDatetime()
 
 
 class _EscapeHatchTime:

--- a/src/time_machine/__init__.py
+++ b/src/time_machine/__init__.py
@@ -413,16 +413,6 @@ def utcnow() -> dt.datetime:
     return dt.datetime.fromtimestamp(time(), dt.timezone.utc).replace(tzinfo=None)
 
 
-def date_today() -> dt.date:
-    # Convert timestamp to date in local timezone
-    return dt.datetime.fromtimestamp(time()).date()
-
-
-def datetime_today() -> dt.datetime:
-    # Convert timestamp to datetime in local timezone
-    return dt.datetime.fromtimestamp(time())
-
-
 # time module
 
 
@@ -547,8 +537,9 @@ if HAVE_PYTEST:  # pragma: no branch
 
 class _EscapeHatchDatetimeDate:
     def today(self) -> dt.date:
-        result: dt.date = _time_machine.original_date_today()
-        return result
+        # date.today() is equivalent to datetime.now().date().
+        result: dt.datetime = _time_machine.original_now(None)
+        return result.date()
 
 
 class _EscapeHatchDatetimeDatetime:
@@ -557,7 +548,8 @@ class _EscapeHatchDatetimeDatetime:
         return result
 
     def today(self) -> dt.datetime:
-        result: dt.datetime = _time_machine.original_datetime_today()
+        # datetime.today() is equivalent to datetime.now() without a timezone.
+        result: dt.datetime = _time_machine.original_now(None)
         return result
 
     def utcnow(self) -> dt.datetime:

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -1317,6 +1317,17 @@ class TestEscapeHatch:
         with time_machine.travel(EPOCH):
             assert time_machine.escape_hatch.is_travelling() is True
 
+    def test_date_today(self):
+        real_today = dt.date.today()
+
+        with time_machine.travel(EPOCH):
+            eh_today = time_machine.escape_hatch.datetime.date.today()
+            assert eh_today >= real_today
+
+        with pytest.raises(ValueError) as excinfo:
+            time_machine.escape_hatch.datetime.date.today()
+        assert excinfo.value.args == ("Not currently time-travelling.",)
+
     def test_datetime_now(self):
         real_now = dt.datetime.now()
 
@@ -1334,6 +1345,17 @@ class TestEscapeHatch:
         with time_machine.travel(EPOCH):
             eh_now = time_machine.escape_hatch.datetime.datetime.now(tz=dt.timezone.utc)
             assert eh_now >= real_now
+
+    def test_datetime_today(self):
+        real_today = dt.datetime.today()
+
+        with time_machine.travel(EPOCH):
+            eh_today = time_machine.escape_hatch.datetime.datetime.today()
+            assert eh_today >= real_today
+
+        with pytest.raises(ValueError) as excinfo:
+            time_machine.escape_hatch.datetime.datetime.today()
+        assert excinfo.value.args == ("Not currently time-travelling.",)
 
     def test_datetime_utcnow(self):
         real_now = dt.datetime.utcnow()


### PR DESCRIPTION
Since datetime.datetime.today() inherits from date.today(), we patch date.today() once with a unified wrapper that checks the calling class type and dispatches to the appropriate function. This ensures both date.today() and datetime.today() work correctly and return the right type.

Related to: https://github.com/python/cpython/commit/fc3e22a06c9b7c93ee379b5554a40a275745e15f
Fixes: https://github.com/adamchainz/time-machine/issues/610

This fix is vibe-coded and tested with Python 3.15 alpha 7, and the code looks reasonable to me. We're going to test it more with packages that use time-machine in Fedora Linux.