### PR TITLE
Make Migration CLI update `freeze_time()` calls that pass `tick`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,10 @@ Changelog
 
 * Stop shipping wheels for free-threaded Python 3.13 since `cibuildwheel 4.0.0 dropped support for building them <https://iscinumpy.dev/post/cibuildwheel-4-0-0/>`__.
 
+* Extend the :ref:`Migration CLI <migration-cli>` to update ``freeze_time()`` calls that pass ``tick``.
+
+  Thanks to George-Cristian Birzan for the report in `Issue #609 <https://github.com/adamchainz/time-machine/issues/609>`__ and tanren for the fix in `PR #636 <https://github.com/adamchainz/time-machine/pull/636>`__.
+
 3.2.0 (2025-12-17)
 ------------------
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -83,8 +83,9 @@ The changes the tool makes are:
 
 * ``from freezegun import freeze_time`` -> ``from time_machine import travel``
 
-* In function decorators, class decorators, and context managers: ``freeze_time(...)`` -> ``travel(..., tick=False)``.
-  This change is only applied when ``freeze_time()`` is called with a single positional argument.
+* In function decorators, class decorators, and context managers: ``freeze_time(...)`` -> ``travel(...)``.
+  This change is applied only when ``freeze_time()`` is called with a single positional argument and up to one keyword argument, ``tick``.
+  If ``tick`` is passed, it is kept as-is, otherwise it is replaced with ``tick=False`` (matching freezegun’s default behaviour).
   In context managers, it’s only applied when the result isn’t assigned to a variable with ``as``.
 
 The tool is open to extension to cover other compatible changes—PRs welcome!

--- a/src/time_machine/cli.py
+++ b/src/time_machine/cli.py
@@ -179,9 +179,10 @@ def visit(tree: ast.Module) -> Mapping[Offset, list[TokenFunc]]:
                         ret[ast_start_offset(decorator.func)].append(
                             partial(switch_to_travel, node=decorator.func)
                         )
-                        ret[ast_start_offset(decorator)].append(
-                            partial(add_tick_false, node=decorator)
-                        )
+                        if not any(kw.arg == "tick" for kw in decorator.keywords):
+                            ret[ast_start_offset(decorator)].append(
+                                partial(add_tick_false, node=decorator)
+                            )
 
             case ast.ClassDef() if node.decorator_list and looks_like_unittest_class(
                 node
@@ -208,9 +209,10 @@ def visit(tree: ast.Module) -> Mapping[Offset, list[TokenFunc]]:
                         ret[ast_start_offset(decorator.func)].append(
                             partial(switch_to_travel, node=decorator.func)
                         )
-                        ret[ast_start_offset(decorator)].append(
-                            partial(add_tick_false, node=decorator)
-                        )
+                        if not any(kw.arg == "tick" for kw in decorator.keywords):
+                            ret[ast_start_offset(decorator)].append(
+                                partial(add_tick_false, node=decorator)
+                            )
 
             case ast.With():
                 for item in node.items:
@@ -237,18 +239,18 @@ def visit(tree: ast.Module) -> Mapping[Offset, list[TokenFunc]]:
                         ret[ast_start_offset(context_expr.func)].append(
                             partial(switch_to_travel, node=context_expr.func)
                         )
-                        ret[ast_start_offset(context_expr)].append(
-                            partial(add_tick_false, node=context_expr)
-                        )
+                        if not any(kw.arg == "tick" for kw in context_expr.keywords):
+                            ret[ast_start_offset(context_expr)].append(
+                                partial(add_tick_false, node=context_expr)
+                            )
 
     return ret  # type: ignore [return-value]
 
 
 def migratable_call(node: ast.Call) -> bool:
-    return (
-        len(node.args) == 1
-        # We could allow tick being set, as long as we didn't then add it
-        and len(node.keywords) == 0
+    return len(node.args) == 1 and (
+        len(node.keywords) == 0
+        or (len(node.keywords) == 1 and node.keywords[0].arg == "tick")
     )
 
 
@@ -362,7 +364,7 @@ def switch_to_travel(
 
 def add_tick_false(tokens: list[Token], i: int, node: ast.Call) -> None:
     """
-    Add `tick=False` to the function call.
+    Add `tick=False` to the function call, unless `tick` is already set.
     """
     j = find_last_token(tokens, i, node=node)
     tokens.insert(j, Token(name=CODE, src=", tick=False"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -246,6 +246,42 @@ class TestMigrateContents:
             """,
         )
 
+    def test_function_decorator_attr_tick(self):
+        check_transformed(
+            """
+            import freezegun
+
+            @freezegun.freeze_time("2023-01-01", tick=True)
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel("2023-01-01", tick=True)
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_function_decorator_attr_tick_false(self):
+        check_transformed(
+            """
+            import freezegun
+
+            @freezegun.freeze_time("2023-01-01", tick=False)
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel("2023-01-01", tick=False)
+            def test_function():
+                pass
+            """,
+        )
+
     def test_function_decorator_name_unrelated(self):
         check_noop(
             """
@@ -288,6 +324,24 @@ class TestMigrateContents:
             import time_machine
 
             @time_machine.travel("2023-01-01", tick=False)
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_function_decorator_name_tick(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            @freeze_time("2023-01-01", tick=True)
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel("2023-01-01", tick=True)
             def test_function():
                 pass
             """,
@@ -447,6 +501,26 @@ class TestMigrateContents:
             class TestClass(TestBase):
                 def setUp(self):
                     print("I look like a unittest class!")
+            """,
+        )
+
+    def test_class_decorator_attr_unittest_class_base_name_tick(self):
+        check_transformed(
+            """
+            import freezegun
+            from django.test import SimpleTestCase
+
+            @freezegun.freeze_time("2023-01-01", tick=True)
+            class TestClass(SimpleTestCase):
+                pass
+            """,
+            """
+            import time_machine
+            from django.test import SimpleTestCase
+
+            @time_machine.travel("2023-01-01", tick=True)
+            class TestClass(SimpleTestCase):
+                pass
             """,
         )
 
@@ -635,6 +709,22 @@ class TestMigrateContents:
             import time_machine
 
             with time_machine.travel("2023-01-01", tick=False):
+                pass
+            """,
+        )
+
+    def test_with_attr_tick(self):
+        check_transformed(
+            """
+            import freezegun
+
+            with freezegun.freeze_time("2023-01-01", tick=True):
+                pass
+            """,
+            """
+            import time_machine
+
+            with time_machine.travel("2023-01-01", tick=True):
                 pass
             """,
         )


### PR DESCRIPTION
Resubmitting #634.

Migrate freeze_time() calls that pass tick

OP wanted to add a check in each branch, but I opted for a single change in `add_tick_false`.

Closes #609