### PR TITLE
Make Migration CLI update `freeze_time()` decorators on async functions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -38,6 +38,10 @@ Changelog
 
   Thanks to George-Cristian Birzan for the report in `Issue #609 <https://github.com/adamchainz/time-machine/issues/609>`__ and tanren for the fix in `PR #636 <https://github.com/adamchainz/time-machine/pull/636>`__.
 
+* Extend the :ref:`Migration CLI <migration-cli>` to rewrite ``freeze_time()`` decorators on async functions.
+
+  Thanks to George-Cristian Birzan for the report in `Issue #608 <https://github.com/adamchainz/time-machine/issues/608>`__ and Sanjay Santhanam for the fix in `PR #640 <https://github.com/adamchainz/time-machine/pull/640>`__.
+
 3.2.0 (2025-12-17)
 ------------------
 

--- a/src/time_machine/cli.py
+++ b/src/time_machine/cli.py
@@ -156,7 +156,7 @@ def visit(tree: ast.Module) -> Mapping[Offset, list[TokenFunc]]:
                 ret[ast_start_offset(node)].append(
                     partial(replace_import_from, node=node)
                 )
-            case ast.FunctionDef():
+            case ast.FunctionDef() | ast.AsyncFunctionDef():
                 for decorator in node.decorator_list:
                     if (
                         isinstance(decorator, ast.Call)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -246,6 +246,24 @@ class TestMigrateContents:
             """,
         )
 
+    def test_async_function_decorator_attr(self):
+        check_transformed(
+            """
+            import freezegun
+
+            @freezegun.freeze_time("2023-01-01")
+            async def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel("2023-01-01", tick=False)
+            async def test_function():
+                pass
+            """,
+        )
+
     def test_function_decorator_attr_tick(self):
         check_transformed(
             """
@@ -343,6 +361,24 @@ class TestMigrateContents:
 
             @time_machine.travel("2023-01-01", tick=True)
             def test_function():
+                pass
+            """,
+        )
+
+    def test_async_function_decorator_name(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            @freeze_time("2023-01-01")
+            async def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel("2023-01-01", tick=False)
+            async def test_function():
                 pass
             """,
         )


### PR DESCRIPTION
Fixes #608

`visit()` only matched `ast.FunctionDef`, so `freeze_time` decorators on `async def` functions were skipped by `time-machine migrate`. Matching `ast.AsyncFunctionDef` too fixes it; regression test added (fails without the change, passes with it).
