### PR TITLE
Migrate freeze_time decorators on async functions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* Fix the migration CLI to rewrite ``freeze_time`` decorators on ``async def`` functions.
+
+  `Issue #608 <https://github.com/adamchainz/time-machine/issues/608>`__.
+
 * Build with frame pointers enabled, preparation for `PEP 831 <https://peps.python.org/pep-0831/>`__.
 
   `PR #627 <https://github.com/adamchainz/time-machine/issues/627>`__.

--- a/src/time_machine/cli.py
+++ b/src/time_machine/cli.py
@@ -156,7 +156,7 @@ def visit(tree: ast.Module) -> Mapping[Offset, list[TokenFunc]]:
                 ret[ast_start_offset(node)].append(
                     partial(replace_import_from, node=node)
                 )
-            case ast.FunctionDef():
+            case ast.FunctionDef() | ast.AsyncFunctionDef():
                 for decorator in node.decorator_list:
                     if (
                         isinstance(decorator, ast.Call)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -293,6 +293,42 @@ class TestMigrateContents:
             """,
         )
 
+    def test_async_function_decorator_name(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            @freeze_time("2023-01-01")
+            async def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel("2023-01-01", tick=False)
+            async def test_function():
+                pass
+            """,
+        )
+
+    def test_async_function_decorator_attr(self):
+        check_transformed(
+            """
+            import freezegun
+
+            @freezegun.freeze_time("2023-01-01")
+            async def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel("2023-01-01", tick=False)
+            async def test_function():
+                pass
+            """,
+        )
+
     def test_class_decorator_attr_unrelated(self):
         check_noop(
             """


### PR DESCRIPTION
Fixes #608.

The decorator scan in `cli.py` matched only `ast.FunctionDef`, so a `freeze_time` decorator on an `async def` was left in place while the `freezegun` import was still rewritten, leaving the file broken. Matching `ast.AsyncFunctionDef` too fixes it; tests cover both the name and attribute decorator forms.
