### PR TITLE
Update documented Python version for free-threading support

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,7 +5,7 @@ Installation
 Requirements
 ------------
 
-Python 3.10 to 3.14 supported, including free-threaded variants from Python 3.13 onwards.
+Python 3.10 to 3.14 supported, including free-threaded variants from Python 3.14 onwards.
 
 Only CPython is supported at this time because time-machine directly hooks into the C-level API.
 


### PR DESCRIPTION
Missed in 6647e60 which dropped the 3.13t wheels.