### PR TITLE
Support isolated subinterpreters

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,14 @@ Changelog
 
   Thanks to Miro Hrončok and Karolina Surma for the report in `Issue #610 <https://github.com/adamchainz/time-machine/issues/610>`__, Lumír 'Frenzy' Balhar for the fix in `PR #618 <https://github.com/adamchainz/time-machine/pull/618>`__, and Maurycy Pawłowski-Wieroński for review
 
+* Support isolated subinterpreters, as created by |concurrent.interpreters|__ on Python 3.14+.
+  Previously, importing time-machine in an isolated subinterpreter failed with an ``ImportError``.
+
+  .. |concurrent.interpreters| replace:: ``concurrent.interpreters``
+  __ https://docs.python.org/3.14/library/concurrent.interpreters.html
+
+  `PR #644 <https://github.com/adamchainz/time-machine/pull/644>`__.
+
 * Move the intermediary functions that patched functions call from Python to C.
   This change reduces the overhead of calling patched functions like ``time.time()`` while time travelling, making them around 10-20% faster.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -15,6 +15,12 @@ This document covers time-machine’s API.
     Also beware that other processes are not affected.
     For example, if you call datetime functions on a database server, they will return the real time.
 
+    Similarly, each interpreter’s time travelling only affects itself, when using |concurrent.interpreters|__.
+    Patched functions called in interpreters that are not travelling fall back to the original functions and return the real time.
+
+    .. |concurrent.interpreters| replace:: ``concurrent.interpreters``
+    __ https://docs.python.org/3.14/library/concurrent.interpreters.html
+
 Main API
 ========
 

--- a/src/_time_machine.c
+++ b/src/_time_machine.c
@@ -9,10 +9,12 @@ typedef struct {
     PyObject *time_module;
     PyObject *datetime_class;
     PyObject *timezone_utc;
-    // time.CLOCK_REALTIME, not always available, e.g. on builds against
-    // old macOS = official Python.org installer
-    int have_clock_realtime;
-    long clock_realtime;
+    PyObject *str_traveller_stack;
+    PyObject *str_time_ns;
+    PyObject *str_replace;
+    PyObject *str_fromtimestamp;
+    PyObject *tzinfo_kwnames;
+    PyObject *nanoseconds_per_second;
     PyCFunctionObject *datetime_datetime_now;
     PyCFunctionObject *datetime_datetime_utcnow;
     PyCFunctionObject *date_today;
@@ -23,21 +25,8 @@ typedef struct {
     PyCFunctionObject *time_strftime;
     PyCFunctionObject *time_time;
     PyCFunctionObject *time_time_ns;
-    // Original method pointers from date and time functions
-#if PY_VERSION_HEX >= 0x030d00a4
-    PyCFunctionFastWithKeywords original_now;
-#else
-    _PyCFunctionFastWithKeywords original_now;
-#endif
-    PyCFunction original_utcnow;
-    PyCFunction original_date_today;
-    PyCFunction original_clock_gettime;
-    PyCFunction original_clock_gettime_ns;
-    PyCFunction original_gmtime;
-    PyCFunction original_localtime;
-    PyCFunction original_strftime;
-    PyCFunction original_time;
-    PyCFunction original_time_ns;
+    // Whether this interpreter has patched the date and time functions
+    int patched;
 } _time_machine_state;
 
 static inline _time_machine_state *
@@ -49,69 +38,154 @@ get_time_machine_state(PyObject *module)
 }
 
 /*
+    Original method pointers from the patched date and time functions. These
+    point to static C functions shared by every interpreter's copy of the
+    datetime and time modules, so, unlike Python objects, they are safe to
+    store in process-wide statics. They are captured at the first patch() and
+    never reset, since unpatched method defs always hold these same pointers.
+*/
+#if PY_VERSION_HEX >= 0x030d00a4
+static PyCFunctionFastWithKeywords original_now = NULL;
+#else
+static _PyCFunctionFastWithKeywords original_now = NULL;
+#endif
+static PyCFunction original_utcnow = NULL;
+static PyCFunction original_date_today = NULL;
+static PyCFunction original_clock_gettime = NULL;
+static PyCFunction original_clock_gettime_ns = NULL;
+static PyCFunction original_gmtime = NULL;
+static PyCFunction original_localtime = NULL;
+static PyCFunction original_strftime = NULL;
+static PyCFunction original_time = NULL;
+static PyCFunction original_time_ns = NULL;
+
+// time.CLOCK_REALTIME, the same for every interpreter. Not always available,
+// e.g. on builds against old macOS = official Python.org installer.
+static int have_clock_realtime = 0;
+static long clock_realtime = 0;
+
+/*
+    Mutex serializing patch() and unpatch() across interpreters, which may
+    run concurrently under per-interpreter GILs (Python 3.12+) or
+    free-threading. Use natively static-initializable locks since PyMutex is
+    only available on Python 3.13+. The critical sections only read and write
+    C pointers, making no blocking calls, so holding a (shared) GIL whilst
+    waiting for this mutex cannot deadlock.
+*/
+#ifdef MS_WINDOWS
+#include <windows.h>
+static SRWLOCK patch_mutex = SRWLOCK_INIT;
+static inline void
+patch_mutex_lock(void)
+{
+    AcquireSRWLockExclusive(&patch_mutex);
+}
+static inline void
+patch_mutex_unlock(void)
+{
+    ReleaseSRWLockExclusive(&patch_mutex);
+}
+#else
+#include <pthread.h>
+static pthread_mutex_t patch_mutex = PTHREAD_MUTEX_INITIALIZER;
+static inline void
+patch_mutex_lock(void)
+{
+    pthread_mutex_lock(&patch_mutex);
+}
+static inline void
+patch_mutex_unlock(void)
+{
+    pthread_mutex_unlock(&patch_mutex);
+}
+#endif
+
+/*
     Helpers for the patched functions. These functions are swapped into other
-    modules' functions, so they don't receive this module as 'self' and
-    instead find its state through sys.modules.
+    modules' functions, so they don't receive this module as 'self'. Instead
+    they look for the time_machine module in sys.modules and this module's
+    state through its `_time_machine` attribute. This finds the state of the
+    current interpreter's copy of the module, so all cached objects are only
+    used within the interpreter that created them.
 */
 
-// Constants used by the patched functions, initialized on first module exec
-// and deliberately never freed, since the patched functions cannot access
-// module state.
-static PyObject *str_traveller_stack = NULL;
-static PyObject *str_time_ns = NULL;
-static PyObject *str_replace = NULL;
-static PyObject *str_fromtimestamp = NULL;
-static PyObject *tzinfo_kwnames = NULL;
-static PyObject *nanoseconds_per_second = NULL;
+/*
+    Return the current interpreter's active traveller,
+    time_machine.traveller_stack[-1], as a new reference, and set *state to
+    the current interpreter's module state.
 
-static _time_machine_state *
-_time_machine_get_module_state(void)
-{
-    PyObject *module = PyImport_ImportModule("_time_machine");
-    if (module == NULL) {
-        return NULL;  // Propagate ImportError
-    }
-    void *state = PyModule_GetState(module);
-    // The reference in sys.modules keeps the module, and thus its state, alive.
-    Py_DECREF(module);
-    return (_time_machine_state *)state;
-}
-
-/* Call time_machine.traveller_stack[-1].time_ns() */
+    Return NULL, with no exception set, if the current interpreter is not
+    time travelling: because time_machine is not imported in it, or no travel
+    is in progress. Patching applies process-wide, so this happens when
+    another interpreter is travelling and this one is not. Callers should
+    then fall back to the original functions.
+*/
 static PyObject *
-_time_machine_traveller_time_ns(void)
+_time_machine_current_traveller(_time_machine_state **state)
 {
-    PyObject *time_machine_module = PyImport_ImportModule("time_machine");
-    if (time_machine_module == NULL) {
-        return NULL;  // Propagate ImportError
+    PyObject *name = PyUnicode_FromString("time_machine");
+    if (name == NULL) {
+        PyErr_Clear();
+        return NULL;
     }
-    PyObject *traveller_stack = PyObject_GetAttr(time_machine_module, str_traveller_stack);
+    // Only look in sys.modules, to avoid triggering an import of
+    // time_machine in interpreters that don't use it.
+    PyObject *time_machine_module = PyImport_GetModule(name);
+    Py_DECREF(name);
+    if (time_machine_module == NULL) {
+        PyErr_Clear();
+        return NULL;
+    }
+
+    PyObject *c_module = PyObject_GetAttrString(time_machine_module, "_time_machine");
+    if (c_module == NULL) {
+        PyErr_Clear();
+        Py_DECREF(time_machine_module);
+        return NULL;
+    }
+    *state = (_time_machine_state *)PyModule_GetState(c_module);
+    // The references in sys.modules and the time_machine module keep this
+    // module, and thus its state, alive.
+    Py_DECREF(c_module);
+    if (*state == NULL || (*state)->str_traveller_stack == NULL) {
+        PyErr_Clear();
+        Py_DECREF(time_machine_module);
+        return NULL;
+    }
+
+    PyObject *traveller_stack =
+        PyObject_GetAttr(time_machine_module, (*state)->str_traveller_stack);
     Py_DECREF(time_machine_module);
     if (traveller_stack == NULL) {
-        return NULL;  // Propagate AttributeError
+        PyErr_Clear();
+        return NULL;
     }
-
     PyObject *traveller = PySequence_GetItem(traveller_stack, -1);
     Py_DECREF(traveller_stack);
     if (traveller == NULL) {
-        return NULL;  // Propagate IndexError
+        PyErr_Clear();
+        return NULL;
     }
-
-    PyObject *result = PyObject_VectorcallMethod(
-        str_time_ns, &traveller, 1 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
-    Py_DECREF(traveller);
-    return result;
+    return traveller;
 }
 
-/* Compute time_machine.traveller_stack[-1].time_ns() / NANOSECONDS_PER_SECOND */
+/* Call traveller.time_ns() */
 static PyObject *
-_time_machine_traveller_time(void)
+_time_machine_traveller_time_ns(PyObject *traveller, _time_machine_state *state)
 {
-    PyObject *time_ns = _time_machine_traveller_time_ns();
+    return PyObject_VectorcallMethod(
+        state->str_time_ns, &traveller, 1 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
+}
+
+/* Compute traveller.time_ns() / NANOSECONDS_PER_SECOND */
+static PyObject *
+_time_machine_traveller_time(PyObject *traveller, _time_machine_state *state)
+{
+    PyObject *time_ns = _time_machine_traveller_time_ns(traveller, state);
     if (time_ns == NULL) {
         return NULL;
     }
-    PyObject *result = PyNumber_TrueDivide(time_ns, nanoseconds_per_second);
+    PyObject *result = PyNumber_TrueDivide(time_ns, state->nanoseconds_per_second);
     Py_DECREF(time_ns);
     return result;
 }
@@ -123,6 +197,12 @@ _time_machine_now(
     PyTypeObject *type, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 
 {
+    _time_machine_state *state;
+    PyObject *traveller = _time_machine_current_traveller(&state);
+    if (traveller == NULL) {
+        return original_now((PyObject *)type, args, nargs, kwnames);
+    }
+
     PyObject *tz = Py_None;
     Py_ssize_t nkwargs = (kwnames != NULL) ? PyTuple_GET_SIZE(kwnames) : 0;
     for (Py_ssize_t i = 0; i < nkwargs; i++) {
@@ -130,6 +210,7 @@ _time_machine_now(
         if (PyUnicode_CompareWithASCIIString(name, "tz") != 0) {
             PyErr_Format(
                 PyExc_TypeError, "now() got an unexpected keyword argument '%U'", name);
+            Py_DECREF(traveller);
             return NULL;
         }
         tz = args[nargs + i];
@@ -137,6 +218,7 @@ _time_machine_now(
     if (nargs + nkwargs > 1) {
         PyErr_Format(
             PyExc_TypeError, "now() takes at most 1 argument (%zd given)", nargs + nkwargs);
+        Py_DECREF(traveller);
         return NULL;
     }
     if (nargs == 1) {
@@ -144,13 +226,14 @@ _time_machine_now(
     }
 
     // cls.fromtimestamp(traveller_time, tz)
-    PyObject *timestamp = _time_machine_traveller_time();
+    PyObject *timestamp = _time_machine_traveller_time(traveller, state);
+    Py_DECREF(traveller);
     if (timestamp == NULL) {
         return NULL;
     }
     PyObject *stack[3] = {(PyObject *)type, timestamp, tz};
     PyObject *result = PyObject_VectorcallMethod(
-        str_fromtimestamp, stack, 3 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
+        state->str_fromtimestamp, stack, 3 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
     Py_DECREF(timestamp);
     return result;
 }
@@ -161,12 +244,12 @@ _time_machine_original_now(
 {
     _time_machine_state *state = get_time_machine_state(module);
 
-    if (state->original_now == NULL) {
+    if (!state->patched) {
         PyErr_SetString(PyExc_ValueError, "Not currently time-travelling.");
         return NULL;
     }
 
-    PyObject *result = state->original_now(state->datetime_class, args, nargs, kwnames);
+    PyObject *result = original_now(state->datetime_class, args, nargs, kwnames);
 
     return result;
 }
@@ -179,11 +262,11 @@ Call datetime.datetime.now() after patching.");
 
 /* Return aware.replace(tzinfo=None), stealing the reference to aware. */
 static PyObject *
-_time_machine_drop_tzinfo(PyObject *aware)
+_time_machine_drop_tzinfo(PyObject *aware, _time_machine_state *state)
 {
     PyObject *stack[2] = {aware, Py_None};
     PyObject *result = PyObject_VectorcallMethod(
-        str_replace, stack, 1 | PY_VECTORCALL_ARGUMENTS_OFFSET, tzinfo_kwnames);
+        state->str_replace, stack, 1 | PY_VECTORCALL_ARGUMENTS_OFFSET, state->tzinfo_kwnames);
     Py_DECREF(aware);
     return result;
 }
@@ -210,9 +293,10 @@ _time_machine_warn_utcnow_deprecated(Py_ssize_t stacklevel)
 static PyObject *
 _time_machine_utcnow(PyObject *cls, PyObject *args)
 {
-    _time_machine_state *state = _time_machine_get_module_state();
-    if (state == NULL) {
-        return NULL;
+    _time_machine_state *state;
+    PyObject *traveller = _time_machine_current_traveller(&state);
+    if (traveller == NULL) {
+        return original_utcnow(cls, args);
     }
 
     // Warn as the original function would, pointing at its caller.
@@ -221,20 +305,23 @@ _time_machine_utcnow(PyObject *cls, PyObject *args)
     }
 
     // cls.fromtimestamp(traveller_time, timezone.utc)
-    PyObject *timestamp = _time_machine_traveller_time();
+    PyObject *timestamp = _time_machine_traveller_time(traveller, state);
+    Py_DECREF(traveller);
     if (timestamp == NULL) {
         return NULL;
     }
     PyObject *fromtimestamp_stack[3] = {cls, timestamp, state->timezone_utc};
-    PyObject *aware = PyObject_VectorcallMethod(
-        str_fromtimestamp, fromtimestamp_stack, 3 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
+    PyObject *aware = PyObject_VectorcallMethod(state->str_fromtimestamp,
+        fromtimestamp_stack,
+        3 | PY_VECTORCALL_ARGUMENTS_OFFSET,
+        NULL);
     Py_DECREF(timestamp);
     if (aware == NULL) {
         return NULL;
     }
 
     // aware.replace(tzinfo=None)
-    return _time_machine_drop_tzinfo(aware);
+    return _time_machine_drop_tzinfo(aware, state);
 }
 
 static PyObject *
@@ -242,7 +329,7 @@ _time_machine_original_utcnow(PyObject *module, PyObject *args)
 {
     _time_machine_state *state = get_time_machine_state(module);
 
-    if (state->original_now == NULL) {
+    if (!state->patched) {
         PyErr_SetString(PyExc_ValueError, "Not currently time-travelling.");
         return NULL;
     }
@@ -262,12 +349,12 @@ _time_machine_original_utcnow(PyObject *module, PyObject *args)
         from returning an aware datetime.
     */
     PyObject *now_args[1] = {state->timezone_utc};
-    PyObject *aware = state->original_now(state->datetime_class, now_args, 1, NULL);
+    PyObject *aware = original_now(state->datetime_class, now_args, 1, NULL);
     if (aware == NULL) {
         return NULL;
     }
 
-    return _time_machine_drop_tzinfo(aware);
+    return _time_machine_drop_tzinfo(aware, state);
 }
 PyDoc_STRVAR(original_utcnow_doc,
     "original_utcnow() -> datetime\n\
@@ -283,14 +370,21 @@ Return what datetime.datetime.utcnow() would, after patching.");
 static PyObject *
 _time_machine_today(PyObject *cls, PyObject *args)
 {
-    PyObject *timestamp = _time_machine_traveller_time();
+    _time_machine_state *state;
+    PyObject *traveller = _time_machine_current_traveller(&state);
+    if (traveller == NULL) {
+        return original_date_today(cls, args);
+    }
+
+    PyObject *timestamp = _time_machine_traveller_time(traveller, state);
+    Py_DECREF(traveller);
     if (timestamp == NULL) {
         return NULL;
     }
 
     PyObject *stack[2] = {cls, timestamp};
     PyObject *result = PyObject_VectorcallMethod(
-        str_fromtimestamp, stack, 2 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
+        state->str_fromtimestamp, stack, 2 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
     Py_DECREF(timestamp);
     return result;
 }
@@ -300,11 +394,6 @@ _time_machine_today(PyObject *cls, PyObject *args)
 static PyObject *
 _time_machine_clock_gettime(PyObject *self, PyObject *args)
 {
-    _time_machine_state *state = _time_machine_get_module_state();
-    if (state == NULL) {
-        return NULL;
-    }
-
 #if PY_VERSION_HEX >= 0x030d00a2
     // METH_O - args is the clk_id itself
     PyObject *clk_id_obj = args;
@@ -319,14 +408,21 @@ _time_machine_clock_gettime(PyObject *self, PyObject *args)
     if (clk_id_obj != NULL && PyLong_Check(clk_id_obj)) {
         int overflow = 0;
         long clk_id = PyLong_AsLongAndOverflow(clk_id_obj, &overflow);
-        if (!overflow && state->have_clock_realtime && clk_id == state->clock_realtime) {
-            return _time_machine_traveller_time();
+        if (!overflow && have_clock_realtime && clk_id == clock_realtime) {
+            _time_machine_state *state;
+            PyObject *traveller = _time_machine_current_traveller(&state);
+            if (traveller != NULL) {
+                PyObject *result = _time_machine_traveller_time(traveller, state);
+                Py_DECREF(traveller);
+                return result;
+            }
         }
-        // Fall through: non-realtime clocks, and out-of-range values, get the
-        // original function's behaviour, including its error messages.
+        // Fall through: non-realtime clocks, out-of-range values, and
+        // interpreters that are not travelling get the original function's
+        // behaviour, including its error messages.
     }
 
-    return state->original_clock_gettime(state->time_module, args);
+    return original_clock_gettime(self, args);
 }
 
 static PyObject *
@@ -334,12 +430,12 @@ _time_machine_original_clock_gettime(PyObject *module, PyObject *args)
 {
     _time_machine_state *state = get_time_machine_state(module);
 
-    if (state->original_clock_gettime == NULL) {
+    if (!state->patched) {
         PyErr_SetString(PyExc_ValueError, "Not currently time-travelling.");
         return NULL;
     }
 
-    PyObject *result = state->original_clock_gettime(state->time_module, args);
+    PyObject *result = original_clock_gettime(state->time_module, args);
 
     return result;
 }
@@ -353,11 +449,6 @@ Call time.clock_gettime() after patching.");
 static PyObject *
 _time_machine_clock_gettime_ns(PyObject *self, PyObject *args)
 {
-    _time_machine_state *state = _time_machine_get_module_state();
-    if (state == NULL) {
-        return NULL;
-    }
-
 #if PY_VERSION_HEX >= 0x030d00a2
     // METH_O - args is the clk_id itself
     PyObject *clk_id_obj = args;
@@ -372,14 +463,21 @@ _time_machine_clock_gettime_ns(PyObject *self, PyObject *args)
     if (clk_id_obj != NULL && PyLong_Check(clk_id_obj)) {
         int overflow = 0;
         long clk_id = PyLong_AsLongAndOverflow(clk_id_obj, &overflow);
-        if (!overflow && state->have_clock_realtime && clk_id == state->clock_realtime) {
-            return _time_machine_traveller_time_ns();
+        if (!overflow && have_clock_realtime && clk_id == clock_realtime) {
+            _time_machine_state *state;
+            PyObject *traveller = _time_machine_current_traveller(&state);
+            if (traveller != NULL) {
+                PyObject *result = _time_machine_traveller_time_ns(traveller, state);
+                Py_DECREF(traveller);
+                return result;
+            }
         }
-        // Fall through: non-realtime clocks, and out-of-range values, get the
-        // original function's behaviour, including its error messages.
+        // Fall through: non-realtime clocks, out-of-range values, and
+        // interpreters that are not travelling get the original function's
+        // behaviour, including its error messages.
     }
 
-    return state->original_clock_gettime_ns(state->time_module, args);
+    return original_clock_gettime_ns(self, args);
 }
 
 static PyObject *
@@ -387,12 +485,12 @@ _time_machine_original_clock_gettime_ns(PyObject *module, PyObject *args)
 {
     _time_machine_state *state = get_time_machine_state(module);
 
-    if (state->original_clock_gettime_ns == NULL) {
+    if (!state->patched) {
         PyErr_SetString(PyExc_ValueError, "Not currently time-travelling.");
         return NULL;
     }
 
-    PyObject *result = state->original_clock_gettime_ns(state->time_module, args);
+    PyObject *result = original_clock_gettime_ns(state->time_module, args);
 
     return result;
 }
@@ -406,18 +504,20 @@ Call time.clock_gettime_ns() after patching.");
 static PyObject *
 _time_machine_gmtime(PyObject *self, PyObject *args)
 {
-    _time_machine_state *state = _time_machine_get_module_state();
-    if (state == NULL) {
-        return NULL;
-    }
-
     Py_ssize_t nargs = PyTuple_GET_SIZE(args);
     if (nargs > 1 || (nargs == 1 && PyTuple_GET_ITEM(args, 0) != Py_None)) {
         // Pass through, including invalid arguments for their error messages.
-        return state->original_gmtime(state->time_module, args);
+        return original_gmtime(self, args);
     }
 
-    PyObject *timestamp = _time_machine_traveller_time();
+    _time_machine_state *state;
+    PyObject *traveller = _time_machine_current_traveller(&state);
+    if (traveller == NULL) {
+        return original_gmtime(self, args);
+    }
+
+    PyObject *timestamp = _time_machine_traveller_time(traveller, state);
+    Py_DECREF(traveller);
     if (timestamp == NULL) {
         return NULL;
     }
@@ -426,7 +526,7 @@ _time_machine_gmtime(PyObject *self, PyObject *args)
     if (new_args == NULL) {
         return NULL;
     }
-    PyObject *result = state->original_gmtime(state->time_module, new_args);
+    PyObject *result = original_gmtime(self, new_args);
     Py_DECREF(new_args);
     return result;
 }
@@ -436,12 +536,12 @@ _time_machine_original_gmtime(PyObject *module, PyObject *args)
 {
     _time_machine_state *state = get_time_machine_state(module);
 
-    if (state->original_gmtime == NULL) {
+    if (!state->patched) {
         PyErr_SetString(PyExc_ValueError, "Not currently time-travelling.");
         return NULL;
     }
 
-    PyObject *result = state->original_gmtime(state->time_module, args);
+    PyObject *result = original_gmtime(state->time_module, args);
 
     return result;
 }
@@ -455,18 +555,20 @@ Call time.gmtime() after patching.");
 static PyObject *
 _time_machine_localtime(PyObject *self, PyObject *args)
 {
-    _time_machine_state *state = _time_machine_get_module_state();
-    if (state == NULL) {
-        return NULL;
-    }
-
     Py_ssize_t nargs = PyTuple_GET_SIZE(args);
     if (nargs > 1 || (nargs == 1 && PyTuple_GET_ITEM(args, 0) != Py_None)) {
         // Pass through, including invalid arguments for their error messages.
-        return state->original_localtime(state->time_module, args);
+        return original_localtime(self, args);
     }
 
-    PyObject *timestamp = _time_machine_traveller_time();
+    _time_machine_state *state;
+    PyObject *traveller = _time_machine_current_traveller(&state);
+    if (traveller == NULL) {
+        return original_localtime(self, args);
+    }
+
+    PyObject *timestamp = _time_machine_traveller_time(traveller, state);
+    Py_DECREF(traveller);
     if (timestamp == NULL) {
         return NULL;
     }
@@ -475,7 +577,7 @@ _time_machine_localtime(PyObject *self, PyObject *args)
     if (new_args == NULL) {
         return NULL;
     }
-    PyObject *result = state->original_localtime(state->time_module, new_args);
+    PyObject *result = original_localtime(self, new_args);
     Py_DECREF(new_args);
     return result;
 }
@@ -485,12 +587,12 @@ _time_machine_original_localtime(PyObject *module, PyObject *args)
 {
     _time_machine_state *state = get_time_machine_state(module);
 
-    if (state->original_localtime == NULL) {
+    if (!state->patched) {
         PyErr_SetString(PyExc_ValueError, "Not currently time-travelling.");
         return NULL;
     }
 
-    PyObject *result = state->original_localtime(state->time_module, args);
+    PyObject *result = original_localtime(state->time_module, args);
 
     return result;
 }
@@ -504,19 +606,21 @@ Call time.localtime() after patching.");
 static PyObject *
 _time_machine_strftime(PyObject *self, PyObject *args)
 {
-    _time_machine_state *state = _time_machine_get_module_state();
-    if (state == NULL) {
-        return NULL;
-    }
-
     Py_ssize_t nargs = PyTuple_GET_SIZE(args);
     if (nargs < 1 || nargs > 2 || (nargs == 2 && PyTuple_GET_ITEM(args, 1) != Py_None)) {
         // Pass through, including invalid arguments for their error messages.
-        return state->original_strftime(state->time_module, args);
+        return original_strftime(self, args);
+    }
+
+    _time_machine_state *state;
+    PyObject *traveller = _time_machine_current_traveller(&state);
+    if (traveller == NULL) {
+        return original_strftime(self, args);
     }
 
     // time.strftime(format, time.localtime(traveller_time))
-    PyObject *timestamp = _time_machine_traveller_time();
+    PyObject *timestamp = _time_machine_traveller_time(traveller, state);
+    Py_DECREF(traveller);
     if (timestamp == NULL) {
         return NULL;
     }
@@ -525,7 +629,7 @@ _time_machine_strftime(PyObject *self, PyObject *args)
     if (localtime_args == NULL) {
         return NULL;
     }
-    PyObject *local_time = state->original_localtime(state->time_module, localtime_args);
+    PyObject *local_time = original_localtime(self, localtime_args);
     Py_DECREF(localtime_args);
     if (local_time == NULL) {
         return NULL;
@@ -535,7 +639,7 @@ _time_machine_strftime(PyObject *self, PyObject *args)
     if (new_args == NULL) {
         return NULL;
     }
-    PyObject *result = state->original_strftime(state->time_module, new_args);
+    PyObject *result = original_strftime(self, new_args);
     Py_DECREF(new_args);
     return result;
 }
@@ -545,12 +649,12 @@ _time_machine_original_strftime(PyObject *module, PyObject *args)
 {
     _time_machine_state *state = get_time_machine_state(module);
 
-    if (state->original_strftime == NULL) {
+    if (!state->patched) {
         PyErr_SetString(PyExc_ValueError, "Not currently time-travelling.");
         return NULL;
     }
 
-    PyObject *result = state->original_strftime(state->time_module, args);
+    PyObject *result = original_strftime(state->time_module, args);
 
     return result;
 }
@@ -564,7 +668,14 @@ Call time.strftime() after patching.");
 static PyObject *
 _time_machine_time(PyObject *self, PyObject *args)
 {
-    return _time_machine_traveller_time();
+    _time_machine_state *state;
+    PyObject *traveller = _time_machine_current_traveller(&state);
+    if (traveller == NULL) {
+        return original_time(self, args);
+    }
+    PyObject *result = _time_machine_traveller_time(traveller, state);
+    Py_DECREF(traveller);
+    return result;
 }
 
 static PyObject *
@@ -572,12 +683,12 @@ _time_machine_original_time(PyObject *module, PyObject *args)
 {
     _time_machine_state *state = get_time_machine_state(module);
 
-    if (state->original_time == NULL) {
+    if (!state->patched) {
         PyErr_SetString(PyExc_ValueError, "Not currently time-travelling.");
         return NULL;
     }
 
-    PyObject *result = state->original_time(state->time_module, args);
+    PyObject *result = original_time(state->time_module, args);
 
     return result;
 }
@@ -591,7 +702,14 @@ Call time.time() after patching.");
 static PyObject *
 _time_machine_time_ns(PyObject *self, PyObject *args)
 {
-    return _time_machine_traveller_time_ns();
+    _time_machine_state *state;
+    PyObject *traveller = _time_machine_current_traveller(&state);
+    if (traveller == NULL) {
+        return original_time_ns(self, args);
+    }
+    PyObject *result = _time_machine_traveller_time_ns(traveller, state);
+    Py_DECREF(traveller);
+    return result;
 }
 
 static PyObject *
@@ -599,12 +717,12 @@ _time_machine_original_time_ns(PyObject *module, PyObject *args)
 {
     _time_machine_state *state = get_time_machine_state(module);
 
-    if (state->original_time_ns == NULL) {
+    if (!state->patched) {
         PyErr_SetString(PyExc_ValueError, "Not currently time-travelling.");
         return NULL;
     }
 
-    PyObject *result = state->original_time_ns(state->time_module, args);
+    PyObject *result = original_time_ns(state->time_module, args);
 
     return result;
 }
@@ -621,29 +739,48 @@ _time_machine_patch(PyObject *module, PyObject *unused)
         return NULL;
     }
 
-    if (state->original_time)
-        Py_RETURN_NONE;
+    patch_mutex_lock();
 
-    state->original_date_today = state->date_today->m_ml->ml_meth;
+    if (state->patched) {
+        patch_mutex_unlock();
+        Py_RETURN_NONE;
+    }
+
+    /*
+        Capture the original method pointers into the process-wide statics
+        before swapping in the patched functions. The ml_meth checks make
+        capture idempotent: if another interpreter has already patched, the
+        patched functions are never captured as originals.
+    */
+
+    if (state->date_today->m_ml->ml_meth != _time_machine_today) {
+        original_date_today = state->date_today->m_ml->ml_meth;
+    }
     state->date_today->m_ml->ml_meth = _time_machine_today;
 
+    if (state->datetime_datetime_now->m_ml->ml_meth != (PyCFunction)_time_machine_now) {
 #if PY_VERSION_HEX >= 0x030d00a4
-    state->original_now =
-        (PyCFunctionFastWithKeywords)state->datetime_datetime_now->m_ml->ml_meth;
+        original_now =
+            (PyCFunctionFastWithKeywords)state->datetime_datetime_now->m_ml->ml_meth;
 #else
-    state->original_now =
-        (_PyCFunctionFastWithKeywords)state->datetime_datetime_now->m_ml->ml_meth;
+        original_now =
+            (_PyCFunctionFastWithKeywords)state->datetime_datetime_now->m_ml->ml_meth;
 #endif
+    }
     state->datetime_datetime_now->m_ml->ml_meth = (PyCFunction)_time_machine_now;
 
-    state->original_utcnow = state->datetime_datetime_utcnow->m_ml->ml_meth;
+    if (state->datetime_datetime_utcnow->m_ml->ml_meth != _time_machine_utcnow) {
+        original_utcnow = state->datetime_datetime_utcnow->m_ml->ml_meth;
+    }
     state->datetime_datetime_utcnow->m_ml->ml_meth = _time_machine_utcnow;
 
     /*
         time.clock_gettime(), only available on Unix platforms.
     */
     if (state->time_clock_gettime != NULL) {
-        state->original_clock_gettime = state->time_clock_gettime->m_ml->ml_meth;
+        if (state->time_clock_gettime->m_ml->ml_meth != _time_machine_clock_gettime) {
+            original_clock_gettime = state->time_clock_gettime->m_ml->ml_meth;
+        }
         state->time_clock_gettime->m_ml->ml_meth = _time_machine_clock_gettime;
     }
 
@@ -651,24 +788,40 @@ _time_machine_patch(PyObject *module, PyObject *unused)
         time.clock_gettime_ns(), only available on Unix platforms.
     */
     if (state->time_clock_gettime_ns != NULL) {
-        state->original_clock_gettime_ns = state->time_clock_gettime_ns->m_ml->ml_meth;
+        if (state->time_clock_gettime_ns->m_ml->ml_meth != _time_machine_clock_gettime_ns) {
+            original_clock_gettime_ns = state->time_clock_gettime_ns->m_ml->ml_meth;
+        }
         state->time_clock_gettime_ns->m_ml->ml_meth = _time_machine_clock_gettime_ns;
     }
 
-    state->original_gmtime = state->time_gmtime->m_ml->ml_meth;
+    if (state->time_gmtime->m_ml->ml_meth != _time_machine_gmtime) {
+        original_gmtime = state->time_gmtime->m_ml->ml_meth;
+    }
     state->time_gmtime->m_ml->ml_meth = _time_machine_gmtime;
 
-    state->original_localtime = state->time_localtime->m_ml->ml_meth;
+    if (state->time_localtime->m_ml->ml_meth != _time_machine_localtime) {
+        original_localtime = state->time_localtime->m_ml->ml_meth;
+    }
     state->time_localtime->m_ml->ml_meth = _time_machine_localtime;
 
-    state->original_strftime = state->time_strftime->m_ml->ml_meth;
+    if (state->time_strftime->m_ml->ml_meth != _time_machine_strftime) {
+        original_strftime = state->time_strftime->m_ml->ml_meth;
+    }
     state->time_strftime->m_ml->ml_meth = _time_machine_strftime;
 
-    state->original_time = state->time_time->m_ml->ml_meth;
+    if (state->time_time->m_ml->ml_meth != _time_machine_time) {
+        original_time = state->time_time->m_ml->ml_meth;
+    }
     state->time_time->m_ml->ml_meth = _time_machine_time;
 
-    state->original_time_ns = state->time_time_ns->m_ml->ml_meth;
+    if (state->time_time_ns->m_ml->ml_meth != _time_machine_time_ns) {
+        original_time_ns = state->time_time_ns->m_ml->ml_meth;
+    }
     state->time_time_ns->m_ml->ml_meth = _time_machine_time_ns;
+
+    state->patched = 1;
+
+    patch_mutex_unlock();
 
     Py_RETURN_NONE;
 }
@@ -685,52 +838,53 @@ _time_machine_unpatch(PyObject *module, PyObject *unused)
         return NULL;
     }
 
-    if (!state->original_time)
+    patch_mutex_lock();
+
+    if (!state->patched) {
+        patch_mutex_unlock();
         Py_RETURN_NONE;
+    }
 
-#if PY_VERSION_HEX >= 0x030d00a4
-    state->datetime_datetime_now->m_ml->ml_meth = (PyCFunction)state->original_now;
-#else
-    state->datetime_datetime_now->m_ml->ml_meth = (PyCFunction)state->original_now;
-#endif
-    state->original_now = NULL;
+    /*
+        Restore the original method pointers from the process-wide statics,
+        which are deliberately not reset: the patched functions use them to
+        fall back for interpreters that are not travelling, which may be
+        while another interpreter remains patched.
+    */
 
-    state->datetime_datetime_utcnow->m_ml->ml_meth = state->original_utcnow;
-    state->original_utcnow = NULL;
+    state->datetime_datetime_now->m_ml->ml_meth = (PyCFunction)original_now;
 
-    state->date_today->m_ml->ml_meth = state->original_date_today;
-    state->original_date_today = NULL;
+    state->datetime_datetime_utcnow->m_ml->ml_meth = original_utcnow;
+
+    state->date_today->m_ml->ml_meth = original_date_today;
 
     /*
         time.clock_gettime(), only available on Unix platforms.
     */
     if (state->time_clock_gettime != NULL) {
-        state->time_clock_gettime->m_ml->ml_meth = state->original_clock_gettime;
-        state->original_clock_gettime = NULL;
+        state->time_clock_gettime->m_ml->ml_meth = original_clock_gettime;
     }
 
     /*
         time.clock_gettime_ns(), only available on Unix platforms.
     */
     if (state->time_clock_gettime_ns != NULL) {
-        state->time_clock_gettime_ns->m_ml->ml_meth = state->original_clock_gettime_ns;
-        state->original_clock_gettime_ns = NULL;
+        state->time_clock_gettime_ns->m_ml->ml_meth = original_clock_gettime_ns;
     }
 
-    state->time_gmtime->m_ml->ml_meth = state->original_gmtime;
-    state->original_gmtime = NULL;
+    state->time_gmtime->m_ml->ml_meth = original_gmtime;
 
-    state->time_localtime->m_ml->ml_meth = state->original_localtime;
-    state->original_localtime = NULL;
+    state->time_localtime->m_ml->ml_meth = original_localtime;
 
-    state->time_strftime->m_ml->ml_meth = state->original_strftime;
-    state->original_strftime = NULL;
+    state->time_strftime->m_ml->ml_meth = original_strftime;
 
-    state->time_time->m_ml->ml_meth = state->original_time;
-    state->original_time = NULL;
+    state->time_time->m_ml->ml_meth = original_time;
 
-    state->time_time_ns->m_ml->ml_meth = state->original_time_ns;
-    state->original_time_ns = NULL;
+    state->time_time_ns->m_ml->ml_meth = original_time_ns;
+
+    state->patched = 0;
+
+    patch_mutex_unlock();
 
     Py_RETURN_NONE;
 }
@@ -799,46 +953,39 @@ _time_machine_exec(PyObject *module)
 {
     _time_machine_state *state = get_time_machine_state(module);
 
-    if (str_traveller_stack == NULL) {
-        str_traveller_stack = PyUnicode_InternFromString("traveller_stack");
-        if (str_traveller_stack == NULL) {
-            goto error;
-        }
+    state->str_traveller_stack = PyUnicode_InternFromString("traveller_stack");
+    if (state->str_traveller_stack == NULL) {
+        goto error;
     }
-    if (str_time_ns == NULL) {
-        str_time_ns = PyUnicode_InternFromString("time_ns");
-        if (str_time_ns == NULL) {
-            goto error;
-        }
+
+    state->str_time_ns = PyUnicode_InternFromString("time_ns");
+    if (state->str_time_ns == NULL) {
+        goto error;
     }
-    if (str_replace == NULL) {
-        str_replace = PyUnicode_InternFromString("replace");
-        if (str_replace == NULL) {
-            goto error;
-        }
+
+    state->str_replace = PyUnicode_InternFromString("replace");
+    if (state->str_replace == NULL) {
+        goto error;
     }
-    if (str_fromtimestamp == NULL) {
-        str_fromtimestamp = PyUnicode_InternFromString("fromtimestamp");
-        if (str_fromtimestamp == NULL) {
-            goto error;
-        }
+
+    state->str_fromtimestamp = PyUnicode_InternFromString("fromtimestamp");
+    if (state->str_fromtimestamp == NULL) {
+        goto error;
     }
-    if (tzinfo_kwnames == NULL) {
-        PyObject *str_tzinfo = PyUnicode_InternFromString("tzinfo");
-        if (str_tzinfo == NULL) {
-            goto error;
-        }
-        tzinfo_kwnames = PyTuple_Pack(1, str_tzinfo);
-        Py_DECREF(str_tzinfo);
-        if (tzinfo_kwnames == NULL) {
-            goto error;
-        }
+
+    PyObject *str_tzinfo = PyUnicode_InternFromString("tzinfo");
+    if (str_tzinfo == NULL) {
+        goto error;
     }
-    if (nanoseconds_per_second == NULL) {
-        nanoseconds_per_second = PyLong_FromLong(1000000000L);
-        if (nanoseconds_per_second == NULL) {
-            goto error;
-        }
+    state->tzinfo_kwnames = PyTuple_Pack(1, str_tzinfo);
+    Py_DECREF(str_tzinfo);
+    if (state->tzinfo_kwnames == NULL) {
+        goto error;
+    }
+
+    state->nanoseconds_per_second = PyLong_FromLong(1000000000L);
+    if (state->nanoseconds_per_second == NULL) {
+        goto error;
     }
 
     state->datetime_module = PyImport_ImportModule("datetime");
@@ -889,25 +1036,23 @@ _time_machine_exec(PyObject *module)
         goto error;
     }
 
-    PyObject *clock_realtime = PyObject_GetAttrString(state->time_module, "CLOCK_REALTIME");
-    if (clock_realtime == NULL) {
-        // time.CLOCK_REALTIME is not always available, e.g. on builds
-        // against old macOS = official Python.org installer
-        if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
-            PyErr_Clear();
-            state->have_clock_realtime = 0;
-        }
-        else {
+    PyObject *clock_realtime_obj =
+        PyObject_GetAttrString(state->time_module, "CLOCK_REALTIME");
+    if (clock_realtime_obj == NULL) {
+        if (!PyErr_ExceptionMatches(PyExc_AttributeError)) {
             goto error;
         }
+        // time.CLOCK_REALTIME is not always available, per the comment on
+        // the have_clock_realtime static.
+        PyErr_Clear();
     }
     else {
-        state->clock_realtime = PyLong_AsLong(clock_realtime);
-        Py_DECREF(clock_realtime);
-        if (state->clock_realtime == -1 && PyErr_Occurred()) {
+        clock_realtime = PyLong_AsLong(clock_realtime_obj);
+        Py_DECREF(clock_realtime_obj);
+        if (clock_realtime == -1 && PyErr_Occurred()) {
             goto error;
         }
-        state->have_clock_realtime = 1;
+        have_clock_realtime = 1;
     }
 
     state->time_clock_gettime =
@@ -969,6 +1114,12 @@ error:
     Py_CLEAR(state->datetime_module);
     Py_CLEAR(state->datetime_class);
     Py_CLEAR(state->timezone_utc);
+    Py_CLEAR(state->str_traveller_stack);
+    Py_CLEAR(state->str_time_ns);
+    Py_CLEAR(state->str_replace);
+    Py_CLEAR(state->str_fromtimestamp);
+    Py_CLEAR(state->tzinfo_kwnames);
+    Py_CLEAR(state->nanoseconds_per_second);
     Py_CLEAR(state->datetime_datetime_now);
     Py_CLEAR(state->datetime_datetime_utcnow);
     Py_CLEAR(state->date_today);
@@ -990,6 +1141,12 @@ _time_machine_traverse(PyObject *module, visitproc visit, void *arg)
     Py_VISIT(state->datetime_module);
     Py_VISIT(state->datetime_class);
     Py_VISIT(state->timezone_utc);
+    Py_VISIT(state->str_traveller_stack);
+    Py_VISIT(state->str_time_ns);
+    Py_VISIT(state->str_replace);
+    Py_VISIT(state->str_fromtimestamp);
+    Py_VISIT(state->tzinfo_kwnames);
+    Py_VISIT(state->nanoseconds_per_second);
     Py_VISIT(state->datetime_datetime_now);
     Py_VISIT(state->datetime_datetime_utcnow);
     Py_VISIT(state->date_today);
@@ -1011,6 +1168,12 @@ _time_machine_clear(PyObject *module)
     Py_CLEAR(state->datetime_module);
     Py_CLEAR(state->datetime_class);
     Py_CLEAR(state->timezone_utc);
+    Py_CLEAR(state->str_traveller_stack);
+    Py_CLEAR(state->str_time_ns);
+    Py_CLEAR(state->str_replace);
+    Py_CLEAR(state->str_fromtimestamp);
+    Py_CLEAR(state->tzinfo_kwnames);
+    Py_CLEAR(state->nanoseconds_per_second);
     Py_CLEAR(state->datetime_datetime_now);
     Py_CLEAR(state->datetime_datetime_utcnow);
     Py_CLEAR(state->date_today);
@@ -1026,6 +1189,11 @@ _time_machine_clear(PyObject *module)
 }
 
 static PyModuleDef_Slot _time_machine_slots[] = {{Py_mod_exec, _time_machine_exec},
+// On Python 3.12+, declare support for isolated subinterpreters, which may
+// each import this module.
+#if PY_VERSION_HEX >= 0x030c0000
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+#endif
 // On Python 3.13+, declare free-threaded support.
 // https://py-free-threading.github.io/porting-extensions/#declaring-free-threaded-support
 #ifdef Py_GIL_DISABLED

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -32,6 +32,9 @@ LIBRARY_EPOCH = LIBRARY_EPOCH_DATETIME.timestamp()
 py_have_clock_gettime = pytest.mark.skipif(
     not hasattr(time, "clock_gettime"), reason="Doesn't have clock_gettime"
 )
+py_have_subinterpreters = pytest.mark.skipif(
+    sys.version_info < (3, 13), reason="subinterpreter API added in Python 3.13"
+)
 py_utcnow_deprecated = pytest.mark.skipif(
     sys.version_info < (3, 12), reason="utcnow() not deprecated before Python 3.12"
 )
@@ -1136,6 +1139,184 @@ def test_uuid_monotonic_within_travel(generate, time_from):
     assert first < second
 
 
+# subinterpreter tests
+
+
+@py_have_subinterpreters
+def test_subinterpreters():
+    """
+    Works in (isolated) subinterpreters, which each import _time_machine
+    separately, including after destroying the interpreter that first
+    imported it. Run in a subprocess so that the first import happens within
+    a subinterpreter.
+    """
+    code = dedent(
+        """
+        import sys
+
+        SUB_CODE = '''
+        import datetime as dt
+        import time
+        import time_machine
+
+        with time_machine.travel(0.0, tick=False):
+            assert time.time() == 0.0
+            assert time.time_ns() == 0
+            assert time.gmtime().tm_year == 1970
+            assert dt.datetime.now(dt.timezone.utc) == dt.datetime(
+                1970, 1, 1, tzinfo=dt.timezone.utc
+            )
+        '''
+
+        if sys.version_info >= (3, 14):
+            from concurrent import interpreters
+
+            for _ in range(2):
+                interp = interpreters.create()
+                try:
+                    interp.exec(SUB_CODE)
+                finally:
+                    interp.close()
+        else:
+            import _interpreters
+
+            for _ in range(2):
+                interp_id = _interpreters.create()
+                try:
+                    excinfo = _interpreters.exec(interp_id, SUB_CODE)
+                    if excinfo is not None:
+                        raise RuntimeError(excinfo.formatted)
+                finally:
+                    _interpreters.destroy(interp_id)
+
+        print("OK")
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "OK\n"
+
+
+@py_have_subinterpreters
+def test_main_interpreter_sees_real_time_while_subinterpreter_travels():
+    """
+    Starting travel in a subinterpreter does not affect the main
+    interpreter, which continues to see the real time while the
+    subinterpreter is travelling, before the subinterpreter is destroyed.
+    """
+    code = dedent(
+        f"""
+        import sys
+        import time
+
+        SUB_CODE = '''
+        import time
+        import time_machine
+        with time_machine.travel(0.0, tick=False):
+            assert time.time() == 0.0, time.time()
+        '''
+
+        assert time.time() >= {LIBRARY_EPOCH}, time.time()
+
+        if sys.version_info >= (3, 14):
+            from concurrent import interpreters
+
+            interp = interpreters.create()
+            interp.exec(SUB_CODE)
+            assert time.time() >= {LIBRARY_EPOCH}, time.time()
+            interp.close()
+        else:
+            import _interpreters
+
+            interp_id = _interpreters.create()
+            excinfo = _interpreters.exec(interp_id, SUB_CODE)
+            if excinfo is not None:
+                raise RuntimeError(excinfo.formatted)
+            assert time.time() >= {LIBRARY_EPOCH}, time.time()
+            _interpreters.destroy(interp_id)
+
+        print("OK")
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "OK\n"
+
+
+@py_have_subinterpreters
+def test_subinterpreters_not_travelling_see_real_time():
+    """
+    Patching applies process-wide, but interpreters that are not travelling
+    fall back to the original functions and see the real time, whether or not
+    they have imported time_machine.
+    """
+    code = dedent(
+        f"""
+        import sys
+        import time
+
+        import time_machine
+
+        SUB_CODE = '''
+        import datetime as dt
+        import time
+        assert time.time() >= {LIBRARY_EPOCH}, time.time()
+        assert dt.datetime.now().year >= 2020
+        assert dt.date.today().year >= 2020
+        import time_machine
+        assert time.time() >= {LIBRARY_EPOCH}, time.time()
+        '''
+
+        with time_machine.travel(0.0, tick=False):
+            assert time.time() == 0.0
+
+            if sys.version_info >= (3, 14):
+                from concurrent import interpreters
+
+                interp = interpreters.create()
+                try:
+                    interp.exec(SUB_CODE)
+                finally:
+                    interp.close()
+            else:
+                import _interpreters
+
+                interp_id = _interpreters.create()
+                try:
+                    excinfo = _interpreters.exec(interp_id, SUB_CODE)
+                    if excinfo is not None:
+                        raise RuntimeError(excinfo.formatted)
+                finally:
+                    _interpreters.destroy(interp_id)
+
+            assert time.time() == 0.0
+
+        print("OK")
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "OK\n"
+
+
 # error handling tests
 
 
@@ -1193,53 +1374,57 @@ def test_c_extension_init_without_clock_realtime():
 
 
 @pytest.mark.parametrize(
-    "func, args",
+    "bad_value",
     [
-        (dt.datetime.now, ()),
-        (dt.datetime.utcnow, ()),
-        (time.gmtime, ()),
-        (time.clock_gettime, (time.CLOCK_REALTIME,)),
-        (time.clock_gettime_ns, (time.CLOCK_REALTIME,)),
-        (time.localtime, ()),
-        (time.strftime, ("%Y-%m-%d",)),
-        (time.time, ()),
-        (time.time_ns, ()),
+        pytest.param(None, id="import blocked"),
+        pytest.param((), id="broken module"),
     ],
 )
-def test_time_machine_import_error(func, args):
-    with (
-        time_machine.travel(EPOCH),
-        mock.patch.dict(sys.modules, {"time_machine": None}),
-        pytest.raises(ModuleNotFoundError) as excinfo,
-    ):
-        func(*args)
+def test_fallback_time_machine_unavailable(bad_value):
+    """
+    If the time_machine module is unavailable or broken in the calling
+    interpreter, patched functions fall back to the original functions and
+    return the real time.
+    """
+    with time_machine.travel(EPOCH):
+        with mock.patch.dict(sys.modules, {"time_machine": bad_value}):
+            assert time.time() >= LIBRARY_EPOCH
+            assert time.time_ns() >= int(LIBRARY_EPOCH * NANOSECONDS_PER_SECOND)
+            assert time.gmtime().tm_year >= 2020
+            assert time.localtime().tm_year >= 2020
+            assert int(time.strftime("%Y")) >= 2020
+            assert dt.datetime.now().year >= 2020
+            assert dt.datetime.now(dt.timezone.utc).year >= 2020
+            assert dt.datetime.utcnow().year >= 2020
+            assert dt.date.today().year >= 2020
 
-    assert excinfo.value.args == ("import of time_machine halted; None in sys.modules",)
+        # Still travelling once time_machine is reachable again.
+        assert time.time() == pytest.approx(EPOCH, abs=10.0)
 
 
+@py_have_clock_gettime
 @pytest.mark.parametrize(
-    "func, args",
+    "bad_value",
     [
-        (dt.datetime.now, ()),
-        (dt.datetime.utcnow, ()),
-        (time.gmtime, ()),
-        (time.clock_gettime, (time.CLOCK_REALTIME,)),
-        (time.clock_gettime_ns, (time.CLOCK_REALTIME,)),
-        (time.localtime, ()),
-        (time.strftime, ("%Y-%m-%d",)),
-        (time.time, ()),
-        (time.time_ns, ()),
+        pytest.param(None, id="import blocked"),
+        pytest.param((), id="broken module"),
     ],
 )
-def test_time_machine_attribute_error(func, args):
-    with (
-        time_machine.travel(EPOCH),
-        mock.patch.dict(sys.modules, {"time_machine": ()}),
-        pytest.raises(AttributeError) as excinfo,
-    ):
-        func(*args)
+def test_fallback_time_machine_unavailable_clock_gettime(bad_value):
+    """
+    If the time_machine module is unavailable or broken in the calling
+    interpreter, patched clock_gettime* functions fall back to the original
+    functions and return the real time.
+    """
+    with time_machine.travel(EPOCH):
+        with mock.patch.dict(sys.modules, {"time_machine": bad_value}):
+            assert time.clock_gettime(time.CLOCK_REALTIME) >= LIBRARY_EPOCH
+            assert time.clock_gettime_ns(time.CLOCK_REALTIME) >= int(
+                LIBRARY_EPOCH * NANOSECONDS_PER_SECOND
+            )
 
-    assert excinfo.value.args == ("'tuple' object has no attribute 'traveller_stack'",)
+        # Still travelling once time_machine is reachable again.
+        assert time.time() == pytest.approx(EPOCH, abs=10.0)
 
 
 # freeezegun conflict tests


### PR DESCRIPTION
Move some cached objects from `static` values (once per process) to module state (once per interpreter). Also, move the original function pointers and `time.CLOCK_REALTIME` values over to `static`, since they do not vary by interpreter.

Declare support for multiple subinterpreters with [`Py_MOD_PER_INTERPRETER_GIL_SUPPORTED`](https://docs.python.org/3/c-api/module.html#c.Py_MOD_PER_INTERPRETER_GIL_SUPPORTED).

Add test cases for the cases where it fails.

Fixes #540.