### PR TITLE
Refactor Migration CLI call rewriting into a shared function

### DIFF
--- a/src/time_machine/cli.py
+++ b/src/time_machine/cli.py
@@ -5,7 +5,7 @@ import ast
 import sys
 import warnings
 from collections import defaultdict
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from functools import partial
 
 from tokenize_rt import (
@@ -134,7 +134,7 @@ def visit(tree: ast.Module) -> Mapping[Offset, list[TokenFunc]]:
     This is a placeholder function; actual implementation would depend on
     the specific migration logic.
     """
-    ret = defaultdict(list)
+    ret: defaultdict[Offset, list[TokenFunc]] = defaultdict(list)
     freezegun_import_seen = False
     freeze_time_import_seen = False
     for node in ast.walk(tree):
@@ -159,93 +159,71 @@ def visit(tree: ast.Module) -> Mapping[Offset, list[TokenFunc]]:
                 )
             case ast.FunctionDef() | ast.AsyncFunctionDef():
                 for decorator in node.decorator_list:
-                    if (
-                        isinstance(decorator, ast.Call)
-                        and migratable_call(decorator)
-                        and (
-                            (
-                                freezegun_import_seen
-                                and isinstance(decorator.func, ast.Attribute)
-                                and decorator.func.attr == "freeze_time"
-                                and isinstance(decorator.func.value, ast.Name)
-                                and decorator.func.value.id == "freezegun"
-                            )
-                            or (
-                                freeze_time_import_seen
-                                and isinstance(decorator.func, ast.Name)
-                                and decorator.func.id == "freeze_time"
-                            )
-                        )
-                    ):
-                        ret[ast_start_offset(decorator.func)].append(
-                            partial(switch_to_travel, node=decorator.func)
-                        )
-                        if not any(kw.arg == "tick" for kw in decorator.keywords):
-                            ret[ast_start_offset(decorator)].append(
-                                partial(add_tick_false, node=decorator)
-                            )
+                    maybe_migrate_call(
+                        ret,
+                        decorator,
+                        freezegun_import_seen=freezegun_import_seen,
+                        freeze_time_import_seen=freeze_time_import_seen,
+                    )
 
             case ast.ClassDef() if node.decorator_list and looks_like_unittest_class(
                 node
             ):
                 for decorator in node.decorator_list:
-                    if (
-                        isinstance(decorator, ast.Call)
-                        and migratable_call(decorator)
-                        and (
-                            (
-                                freezegun_import_seen
-                                and isinstance(decorator.func, ast.Attribute)
-                                and decorator.func.attr == "freeze_time"
-                                and isinstance(decorator.func.value, ast.Name)
-                                and decorator.func.value.id == "freezegun"
-                            )
-                            or (
-                                freeze_time_import_seen
-                                and isinstance(decorator.func, ast.Name)
-                                and decorator.func.id == "freeze_time"
-                            )
-                        )
-                    ):
-                        ret[ast_start_offset(decorator.func)].append(
-                            partial(switch_to_travel, node=decorator.func)
-                        )
-                        if not any(kw.arg == "tick" for kw in decorator.keywords):
-                            ret[ast_start_offset(decorator)].append(
-                                partial(add_tick_false, node=decorator)
-                            )
+                    maybe_migrate_call(
+                        ret,
+                        decorator,
+                        freezegun_import_seen=freezegun_import_seen,
+                        freeze_time_import_seen=freeze_time_import_seen,
+                    )
 
             case ast.With():
                 for item in node.items:
-                    context_expr = item.context_expr
-                    if (
-                        isinstance(context_expr, ast.Call)
-                        and migratable_call(context_expr)
-                        and item.optional_vars is None
-                        and (
-                            (
-                                freezegun_import_seen
-                                and isinstance(context_expr.func, ast.Attribute)
-                                and context_expr.func.attr == "freeze_time"
-                                and isinstance(context_expr.func.value, ast.Name)
-                                and context_expr.func.value.id == "freezegun"
-                            )
-                            or (
-                                freeze_time_import_seen
-                                and isinstance(context_expr.func, ast.Name)
-                                and context_expr.func.id == "freeze_time"
-                            )
+                    if item.optional_vars is None:
+                        maybe_migrate_call(
+                            ret,
+                            item.context_expr,
+                            freezegun_import_seen=freezegun_import_seen,
+                            freeze_time_import_seen=freeze_time_import_seen,
                         )
-                    ):
-                        ret[ast_start_offset(context_expr.func)].append(
-                            partial(switch_to_travel, node=context_expr.func)
-                        )
-                        if not any(kw.arg == "tick" for kw in context_expr.keywords):
-                            ret[ast_start_offset(context_expr)].append(
-                                partial(add_tick_false, node=context_expr)
-                            )
 
-    return ret  # type: ignore [return-value]
+    return ret
+
+
+def maybe_migrate_call(
+    ret: MutableMapping[Offset, list[TokenFunc]],
+    node: ast.expr,
+    *,
+    freezegun_import_seen: bool,
+    freeze_time_import_seen: bool,
+) -> None:
+    """
+    Add the callbacks to rewrite the given expression, if it is a migratable
+    call to freezegun’s freeze_time().
+    """
+    if not isinstance(node, ast.Call) or not migratable_call(node):
+        return
+
+    func = node.func
+    if not (
+        (
+            freezegun_import_seen
+            and isinstance(func, ast.Attribute)
+            and func.attr == "freeze_time"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "freezegun"
+        )
+        or (
+            freeze_time_import_seen
+            and isinstance(func, ast.Name)
+            and func.id == "freeze_time"
+        )
+    ):
+        return
+
+    ret[ast_start_offset(func)].append(partial(switch_to_travel, node=func))
+    if not any(kw.arg == "tick" for kw in node.keywords):
+        ret[ast_start_offset(node)].append(partial(add_tick_false, node=node))
 
 
 def migratable_call(node: ast.Call) -> bool:


### PR DESCRIPTION
Move the shared logic for detecting and rewriting a migratable `freeze_time()` call into a new function, `maybe_migrate_call()`, to avoid code duplication across function decorators, class decorators, and context managers.