### PR TITLE
Make Migration CLI rewrite `freeze_time` from-imports with several names

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -47,6 +47,11 @@ Changelog
 
   `PR #645 <https://github.com/adamchainz/time-machine/pull/645>`__.
 
+* Extend the :ref:`Migration CLI <migration-cli>` to rewrite from-imports that import ``freeze_time`` alongside other names.
+  For example, ``from freezegun import freeze_time, FakeDate`` now becomes ``import time_machine`` plus ``from freezegun import FakeDate``.
+
+  `PR #647 <https://github.com/adamchainz/time-machine/pull/647>`__.
+
 3.2.0 (2025-12-17)
 ------------------
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -81,7 +81,9 @@ The changes the tool makes are:
 
 * ``import freezegun`` -> ``import time_machine``
 
-* ``from freezegun import freeze_time`` -> ``from time_machine import travel``
+* ``from freezegun import freeze_time`` -> ``import time_machine``
+
+* ``from freezegun import freeze_time, FakeDate`` -> ``import time_machine`` plus ``from freezegun import FakeDate``, keeping the other imported names.
 
 * In function decorators, class decorators, and context managers: ``freeze_time(...)`` -> ``travel(...)``.
   This change is applied only when ``freeze_time()`` is called with a single positional argument and up to one keyword argument, ``tick``.

--- a/src/time_machine/cli.py
+++ b/src/time_machine/cli.py
@@ -19,6 +19,7 @@ from tokenize_rt import (
 
 CODE = "CODE"
 DEDENT = "DEDENT"
+INDENT = "INDENT"
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -149,13 +150,22 @@ def visit(tree: ast.Module) -> Mapping[Offset, list[TokenFunc]]:
             case ast.ImportFrom() if (
                 node.level == 0
                 and node.module == "freezegun"
-                and len(node.names) == 1
-                and (alias := node.names[0]).name == "freeze_time"
-                and alias.asname is None
+                and any(
+                    alias.name == "freeze_time" and alias.asname is None
+                    for alias in node.names
+                )
             ):
                 freeze_time_import_seen = True
                 ret[ast_start_offset(node)].append(
-                    partial(replace_import_from, node=node)
+                    partial(
+                        replace_import_from,
+                        node=node,
+                        keep=[
+                            unparse_alias(alias)
+                            for alias in node.names
+                            if alias.name != "freeze_time" or alias.asname is not None
+                        ],
+                    )
                 )
             case ast.FunctionDef() | ast.AsyncFunctionDef():
                 for decorator in node.decorator_list:
@@ -329,9 +339,34 @@ def replace_import(tokens: list[Token], i: int) -> None:
     tokens[i] = Token(name="NAME", src="time_machine")
 
 
-def replace_import_from(tokens: list[Token], i: int, node: ast.ImportFrom) -> None:
+def unparse_alias(alias: ast.alias) -> str:
+    if alias.asname is not None:
+        return f"{alias.name} as {alias.asname}"
+    return alias.name
+
+
+def replace_import_from(
+    tokens: list[Token], i: int, node: ast.ImportFrom, keep: list[str]
+) -> None:
+    """
+    Replace a from-import of freeze_time with `import time_machine`, re-adding
+    a from-import of any other names that were imported alongside it.
+    """
     j = find_last_token(tokens, i, node=node)
-    tokens[i : j + 1] = [Token(name=CODE, src="import time_machine")]
+    src = "import time_machine"
+    if keep:
+        src += f"\n{line_indent(tokens, i)}from {node.module} import {', '.join(keep)}"
+    tokens[i : j + 1] = [Token(name=CODE, src=src)]
+
+
+def line_indent(tokens: list[Token], i: int) -> str:
+    """
+    Return the whitespace indenting the line that the given token starts.
+    """
+    if i > 0 and tokens[i - 1].name in (INDENT, UNIMPORTANT_WS):
+        # no types for tokenize-rt
+        return tokens[i - 1].src  # type: ignore [no-any-return]
+    return ""
 
 
 def switch_to_travel(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -182,8 +182,81 @@ class TestMigrateContents:
         )
 
     def test_import_from_freezegun_multiple(self):
-        check_noop(
+        check_transformed(
             "from freezegun import freeze_time, FakeDate",
+            "import time_machine\nfrom freezegun import FakeDate",
+        )
+
+    def test_import_from_freezegun_multiple_aliased(self):
+        check_transformed(
+            "from freezegun import freeze_time, FakeDate as FD",
+            "import time_machine\nfrom freezegun import FakeDate as FD",
+        )
+
+    def test_import_from_freezegun_multiple_only_aliased_freeze_time(self):
+        check_noop(
+            "from freezegun import freeze_time as ft, FakeDate",
+        )
+
+    def test_import_from_freezegun_multiple_parenthesized(self):
+        check_transformed(
+            """\
+            from freezegun import (
+                freeze_time,
+                FakeDate,
+            )
+            """,
+            """\
+            import time_machine
+            from freezegun import FakeDate
+            """,
+        )
+
+    def test_import_from_freezegun_multiple_indented(self):
+        check_transformed(
+            """\
+            def f():
+                from freezegun import freeze_time, FakeDate
+            """,
+            """\
+            def f():
+                import time_machine
+                from freezegun import FakeDate
+            """,
+        )
+
+    def test_import_from_freezegun_multiple_indented_not_first_statement(self):
+        check_transformed(
+            """\
+            def f():
+                x = 1
+                from freezegun import freeze_time, FakeDate
+            """,
+            """\
+            def f():
+                x = 1
+                import time_machine
+                from freezegun import FakeDate
+            """,
+        )
+
+    def test_import_from_freezegun_multiple_used(self):
+        check_transformed(
+            """\
+            from freezegun import freeze_time, FakeDate
+
+            @freeze_time("2023-01-01")
+            def test_function():
+                pass
+            """,
+            """\
+            import time_machine
+            from freezegun import FakeDate
+
+            @time_machine.travel("2023-01-01", tick=False)
+            def test_function():
+                pass
+            """,
         )
 
     def test_import_from_freezegun(self):


### PR DESCRIPTION
`from freezegun import freeze_time, FakeDate` was previously left alone, so the calls in the file were left alone too. Rewrite it to `import time_machine` plus a from-import of the remaining names, preserving the indentation of the original statement.

Also fix the documented rewrite of a single-name from-import, which has produced `import time_machine` rather than `from time_machine import travel`.