### PR TITLE
Reset uuid module's cached timestamps when time travelling backwards

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,17 @@
 Changelog
 =========
 
+* Fix the standard |uuid|__ library functions ``uuid1()``, ``uuid6()``, and ``uuid7()`` to correctly generate values for the destination when time travels backwards.
+  These functions cache the timestamp of the value they generated most recently, and never generate a value stamped before it.
+  Previously, after time-travelling backwards, these functions would keep generating values stamped for the cached timestamp, rather than the new destination.
+  The caches are now reset whenever time travel starts, stops, or moves backwards.
+
+  .. |uuid| replace:: ``uuid``
+  __ https://docs.python.org/3/library/uuid.html
+
+  `PR #648 <https://github.com/adamchainz/time-machine/pull/648>`__.
+  Thanks to Diego Carrasco for the report in `Issue #601 <https://github.com/adamchainz/time-machine/issues/601>`__ and initial work in `PR #597 <https://github.com/adamchainz/time-machine/pull/597>`__.
+
 * Support Python 3.15.
 
   `PR #631 <https://github.com/adamchainz/time-machine/pull/631>`__.

--- a/src/time_machine/__init__.py
+++ b/src/time_machine/__init__.py
@@ -67,6 +67,21 @@ SYSTEM_EPOCH_TIMESTAMP_NS = int(
     * NANOSECONDS_PER_SECOND
 )
 
+# uuid1(), uuid6(), and uuid7() cache the timestamp of the last value they
+# generated in a module-level global, and never generate a value before it.
+# We therefore clear those caches when we travel backwards in time, so that
+# those functions generate values with correct timestamps.
+_uuid_dict = uuid.__dict__
+_uuid_reset = {"_last_timestamp": None}
+if sys.version_info >= (3, 14):
+    _uuid_reset["_last_timestamp_v6"] = None
+    _uuid_reset["_last_timestamp_v7"] = None
+
+
+def _reset_uuid_timestamps() -> None:
+    _uuid_dict.update(_uuid_reset)
+
+
 DestinationBaseType: TypeAlias = (
     int | float | dt.datetime | dt.timedelta | dt.date | str
 )
@@ -217,6 +232,11 @@ class Traveller:
 
         self._destination_timestamp_ns += int(total_seconds * NANOSECONDS_PER_SECOND)
 
+        if total_seconds < 0:
+            # Moving forwards leaves the cached uuid timestamps in the past, so
+            # only pay for resetting them when moving backwards.
+            _reset_uuid_timestamps()
+
     def move_to(
         self,
         destination: DestinationType,
@@ -231,6 +251,8 @@ class Traveller:
             self._tick = tick
 
     def _start(self) -> None:
+        _reset_uuid_timestamps()
+
         if HAVE_TZSET and self._destination_tzname is not None:
             self._orig_tz = os.environ.get("TZ")
             os.environ["TZ"] = self._destination_tzname
@@ -288,6 +310,8 @@ class travel:
 
     def stop(self) -> None:
         traveller_stack.pop()._stop()
+
+        _reset_uuid_timestamps()
 
         if not traveller_stack:
             _time_machine.unpatch()

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -987,6 +987,19 @@ def time_from_uuid1(value: uuid.UUID) -> dt.datetime:
     return dt.datetime(1582, 10, 15) + dt.timedelta(microseconds=value.time // 10)
 
 
+time_from_uuid6 = time_from_uuid1
+
+
+def time_from_uuid7(value: uuid.UUID) -> dt.datetime:
+    return dt.datetime(1970, 1, 1) + dt.timedelta(milliseconds=value.time)
+
+
+uuid_generators = [pytest.param(uuid.uuid1, time_from_uuid1, id="uuid1")]
+if sys.version_info >= (3, 14):
+    uuid_generators.append(pytest.param(uuid.uuid6, time_from_uuid6, id="uuid6"))
+    uuid_generators.append(pytest.param(uuid.uuid7, time_from_uuid7, id="uuid7"))
+
+
 def test_uuid1():
     """
     Test that the uuid.uuid1() methods generate values for the destination.
@@ -997,6 +1010,89 @@ def test_uuid1():
 
     with time_machine.travel(destination, tick=False):
         assert time_from_uuid1(uuid.uuid1()) == destination
+
+
+@pytest.mark.parametrize(("generate", "time_from"), uuid_generators)
+def test_uuid_travel_backwards(generate, time_from):
+    future = dt.datetime(2056, 2, 6, 14, 3, 21)
+    past = dt.datetime(1978, 7, 6, 23, 6, 31)
+
+    with time_machine.travel(future, tick=False):
+        assert time_from(generate()) == future
+
+    with time_machine.travel(past, tick=False):
+        assert time_from(generate()) == past
+
+
+@pytest.mark.parametrize(("generate", "time_from"), uuid_generators)
+def test_uuid_travel_backwards_nested(generate, time_from):
+    future = dt.datetime(2056, 2, 6, 14, 3, 21)
+    past = dt.datetime(1978, 7, 6, 23, 6, 31)
+
+    with time_machine.travel(EPOCH_PLUS_ONE_YEAR_DATETIME, tick=False):
+        with time_machine.travel(future, tick=False):
+            assert time_from(generate()) == future
+
+        assert time_from(generate()) == EPOCH_PLUS_ONE_YEAR_DATETIME.replace(
+            tzinfo=None
+        )
+
+        with time_machine.travel(past, tick=False):
+            assert time_from(generate()) == past
+
+
+@pytest.mark.parametrize(("generate", "time_from"), uuid_generators)
+def test_uuid_shift_backwards(generate, time_from):
+    destination = dt.datetime(2056, 2, 6, 14, 3, 21)
+
+    with time_machine.travel(destination, tick=False) as traveller:
+        assert time_from(generate()) == destination
+
+        traveller.shift(-dt.timedelta(days=1))
+
+        assert time_from(generate()) == destination - dt.timedelta(days=1)
+
+
+@pytest.mark.parametrize(("generate", "time_from"), uuid_generators)
+def test_uuid_move_to_backwards(generate, time_from):
+    future = dt.datetime(2056, 2, 6, 14, 3, 21)
+    past = dt.datetime(1978, 7, 6, 23, 6, 31)
+
+    with time_machine.travel(future, tick=False) as traveller:
+        assert time_from(generate()) == future
+
+        traveller.move_to(past)
+
+        assert time_from(generate()) == past
+
+
+@pytest.mark.parametrize(("generate", "time_from"), uuid_generators)
+def test_uuid_after_travel(generate, time_from):
+    """
+    Travelling to the future should not leave the uuid module stuck there
+    after time travel has stopped.
+    """
+    with time_machine.travel(dt.datetime(2056, 2, 6, 14, 3, 21), tick=False):
+        generate()
+
+    now = dt.datetime.now(dt.timezone.utc).replace(tzinfo=None)
+    assert abs(time_from(generate()) - now) < dt.timedelta(seconds=10)
+
+
+@pytest.mark.parametrize(("generate", "time_from"), uuid_generators)
+def test_uuid_monotonic_within_travel(generate, time_from):
+    """
+    Resetting the cached timestamps should not break the ordering guarantee
+    for values generated at a single point in time.
+    """
+    destination = dt.datetime(2056, 2, 6, 14, 3, 21)
+
+    with time_machine.travel(destination, tick=False):
+        first = generate()
+        second = generate()
+
+    assert time_from(first) == destination
+    assert first < second
 
 
 # error handling tests


### PR DESCRIPTION
Fixes #601.