### PR TITLE
Raise the `DeprecationWarning` for `utcnow()` while time travelling

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,6 +35,18 @@ Changelog
 
   `PR #643 <https://github.com/adamchainz/time-machine/pull/643>`__.
 
+* Fix hiding of the ``DeprecationWarning`` from |datetime.utcnow()|__ on Python 3.12+ while time travelling.
+  Previously, the mocked version of the function did not raise the warning at all, so deprecated calls could pass unnoticed in tests.
+  The warning is attributed to the calling code, like the real function does.
+
+  .. |datetime.utcnow()| replace:: ``datetime.utcnow()``
+  __ https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow
+
+  The :ref:`escape hatch <escape-hatch>` function ``escape_hatch.datetime.datetime.utcnow()`` also now attributes its warning to the calling code, rather than to a line within time-machine.
+
+  `PR #649 <https://github.com/adamchainz/time-machine/pull/>`__.
+  Thanks to Tamir Duberstein for the report in `Issue #445 <https://github.com/adamchainz/time-machine/issues/445>`__ and Anders Kaseorg for the initial implementation in `PR #486 <https://github.com/adamchainz/time-machine/pull/486>`__.
+
 * Build with frame pointers enabled, preparation for `PEP 831 <https://peps.python.org/pep-0831/>`__.
 
   `PR #627 <https://github.com/adamchainz/time-machine/issues/627>`__.

--- a/src/_time_machine.c
+++ b/src/_time_machine.c
@@ -177,11 +177,46 @@ Call datetime.datetime.now() after patching.");
 
 /* datetime.datetime.utcnow() */
 
+/* Return aware.replace(tzinfo=None), stealing the reference to aware. */
+static PyObject *
+_time_machine_drop_tzinfo(PyObject *aware)
+{
+    PyObject *stack[2] = {aware, Py_None};
+    PyObject *result = PyObject_VectorcallMethod(
+        str_replace, stack, 1 | PY_VECTORCALL_ARGUMENTS_OFFSET, tzinfo_kwnames);
+    Py_DECREF(aware);
+    return result;
+}
+
+/*
+    Copy Python 3.12’s DeprecationWarning for datetime.datetime.utcnow().
+    Returns 0 on success, -1 with an exception set, like PyErr_WarnEx().
+*/
+static int
+_time_machine_warn_utcnow_deprecated(Py_ssize_t stacklevel)
+{
+#if PY_VERSION_HEX >= 0x030c0000
+    return PyErr_WarnEx(PyExc_DeprecationWarning,
+        "datetime.datetime.utcnow() is deprecated and scheduled for removal in "
+        "a future version. Use timezone-aware objects to represent datetimes "
+        "in UTC: datetime.datetime.now(datetime.UTC).",
+        stacklevel);
+#else
+    (void)stacklevel;
+    return 0;
+#endif
+}
+
 static PyObject *
 _time_machine_utcnow(PyObject *cls, PyObject *args)
 {
     _time_machine_state *state = _time_machine_get_module_state();
     if (state == NULL) {
+        return NULL;
+    }
+
+    // Warn as the original function would, pointing at its caller.
+    if (_time_machine_warn_utcnow_deprecated(1) < 0) {
         return NULL;
     }
 
@@ -199,11 +234,7 @@ _time_machine_utcnow(PyObject *cls, PyObject *args)
     }
 
     // aware.replace(tzinfo=None)
-    PyObject *stack[2] = {aware, Py_None};
-    PyObject *result = PyObject_VectorcallMethod(
-        str_replace, stack, 1 | PY_VECTORCALL_ARGUMENTS_OFFSET, tzinfo_kwnames);
-    Py_DECREF(aware);
-    return result;
+    return _time_machine_drop_tzinfo(aware);
 }
 
 static PyObject *
@@ -211,19 +242,37 @@ _time_machine_original_utcnow(PyObject *module, PyObject *args)
 {
     _time_machine_state *state = get_time_machine_state(module);
 
-    if (state->original_utcnow == NULL) {
+    if (state->original_now == NULL) {
         PyErr_SetString(PyExc_ValueError, "Not currently time-travelling.");
         return NULL;
     }
 
-    PyObject *result = state->original_utcnow(state->datetime_class, args);
+    /*
+        Warn pointing at the caller of the Python wrapper in time_machine that
+        calls this function (stacklevel 2), rather than the wrapper itself.
+    */
+    if (_time_machine_warn_utcnow_deprecated(2) < 0) {
+        return NULL;
+    }
 
-    return result;
+    /*
+        Calling the original datetime.datetime.utcnow() would raise a second,
+        misattributed DeprecationWarning on Python 3.12+. Use the original
+        datetime.datetime.now(timezone.utc) instead, which is equivalent apart
+        from returning an aware datetime.
+    */
+    PyObject *now_args[1] = {state->timezone_utc};
+    PyObject *aware = state->original_now(state->datetime_class, now_args, 1, NULL);
+    if (aware == NULL) {
+        return NULL;
+    }
+
+    return _time_machine_drop_tzinfo(aware);
 }
 PyDoc_STRVAR(original_utcnow_doc,
     "original_utcnow() -> datetime\n\
 \n\
-Call datetime.datetime.utcnow() after patching.");
+Return what datetime.datetime.utcnow() would, after patching.");
 
 /* datetime.date.today() and datetime.datetime.today()
  * Note: datetime.datetime doesn't define its own today(), it inherits from date.

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -8,7 +8,9 @@ import sys
 import time
 import typing
 import uuid
+import warnings
 from contextlib import contextmanager
+from pathlib import Path
 from textwrap import dedent
 from unittest import SkipTest, TestCase, mock
 from zoneinfo import ZoneInfo
@@ -30,6 +32,24 @@ LIBRARY_EPOCH = LIBRARY_EPOCH_DATETIME.timestamp()
 py_have_clock_gettime = pytest.mark.skipif(
     not hasattr(time, "clock_gettime"), reason="Doesn't have clock_gettime"
 )
+py_utcnow_deprecated = pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="utcnow() not deprecated before Python 3.12"
+)
+py_utcnow_not_deprecated = pytest.mark.skipif(
+    sys.version_info >= (3, 12), reason="utcnow() deprecated on Python 3.12+"
+)
+
+
+file_source = Path(__file__).read_text().splitlines()
+
+
+def assert_warned_here(record: warnings.WarningMessage) -> None:
+    """
+    Assert the warning was attributed to a line marked with a trailing
+    “# warns here” comment, rather than to time-machine’s own code.
+    """
+    assert record.filename == __file__
+    assert file_source[record.lineno - 1].endswith("# warns here")
 
 
 def sleep_one_cycle(clock: int) -> None:
@@ -127,6 +147,27 @@ def test_datetime_utcnow():
         assert now.microsecond == 0
         assert now.tzinfo is None
     assert dt.datetime.utcnow() >= LIBRARY_EPOCH_DATETIME
+
+
+@py_utcnow_deprecated
+def test_datetime_utcnow_deprecation_warning():
+    with pytest.warns(DeprecationWarning) as unpatched_records:
+        dt.datetime.utcnow()  # warns here
+    assert_warned_here(unpatched_records[0])
+
+    with time_machine.travel(EPOCH), pytest.warns(DeprecationWarning) as records:
+        dt.datetime.utcnow()  # warns here
+
+    assert len(records) == 1
+    assert str(records[0].message) == str(unpatched_records[0].message)
+    assert_warned_here(records[0])
+
+
+@py_utcnow_not_deprecated
+def test_datetime_utcnow_no_deprecation_warning():
+    with time_machine.travel(EPOCH), warnings.catch_warnings():
+        warnings.simplefilter("error")
+        dt.datetime.utcnow()
 
 
 def test_datetime_utcnow_no_tick():
@@ -1576,6 +1617,25 @@ class TestEscapeHatch:
         with pytest.raises(ValueError) as excinfo:
             time_machine.escape_hatch.datetime.datetime.utcnow()
         assert excinfo.value.args == ("Not currently time-travelling.",)
+
+    @py_utcnow_deprecated
+    def test_datetime_utcnow_deprecation_warning(self):
+        with pytest.warns(DeprecationWarning) as unpatched_records:
+            dt.datetime.utcnow()  # warns here
+        assert_warned_here(unpatched_records[0])
+
+        with time_machine.travel(EPOCH), pytest.warns(DeprecationWarning) as records:
+            time_machine.escape_hatch.datetime.datetime.utcnow()  # warns here
+
+        assert len(records) == 1
+        assert str(records[0].message) == str(unpatched_records[0].message)
+        assert_warned_here(records[0])
+
+    @py_utcnow_not_deprecated
+    def test_datetime_utcnow_no_deprecation_warning(self):
+        with time_machine.travel(EPOCH), warnings.catch_warnings():
+            warnings.simplefilter("error")
+            time_machine.escape_hatch.datetime.datetime.utcnow()
 
     @py_have_clock_gettime
     def test_time_clock_gettime(self):


### PR DESCRIPTION
Fixes #445.

The patched `datetime.utcnow()` computes the destination time itself, without calling the original function, so on Python 3.12+ it silently skipped that function's `DeprecationWarning`. Deprecated calls could thus pass unnoticed in tests using time-machine.

This PR changes the patched function to raise the warning itself, with the message copied from CPython.

Similarly, the escape hatch function `escape_hatch.datetime.datetime.utcnow()` now raises the warning itself, rather than calling the original function, which would raise a second, misattributed warning.