### PR TITLE
Add Hypothesis fuzz tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,11 +54,8 @@ entry-points.pytest11.time_machine = "time_machine"
 
 [dependency-groups]
 test = [
-  "coverage[toml]",
-  "freezegun",
-  "pytest>=9",
-  "pytest-randomly",
-  "python-dateutil",
+  "hypothesis",
+  { include-group = "test-base" },
 ]
 docs = [
   "furo>=2024.8.6",
@@ -68,6 +65,13 @@ docs = [
 ]
 build = [
   "cibuildwheel>=3.3.1",
+]
+test-base = [
+  "coverage[toml]",
+  "freezegun",
+  "pytest>=9",
+  "pytest-randomly",
+  "python-dateutil",
 ]
 
 [tool.uv]

--- a/tests/test_fuzz.py
+++ b/tests/test_fuzz.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import datetime as dt
+import sys
+import time
+
+import pytest
+
+if sys.version_info[:2] == (3, 13) and not sys._is_gil_enabled():
+    # Hypothesis has no free-threaded wheels for Python 3.13, and cannot be
+    # built from source there, since PyO3 does not support free-threaded
+    # Python < 3.14.
+    pytest.skip("Hypothesis unavailable", allow_module_level=True)
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+import time_machine
+
+NANOSECONDS_PER_SECOND = time_machine.NANOSECONDS_PER_SECOND
+EPOCH_AWARE = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
+
+# Bounds that keep generated timestamps positive, whatever timezone offset is
+# applied, and well within the range that all supported platforms can convert.
+MIN_DATETIME = dt.datetime(1970, 1, 2)
+MAX_DATETIME = dt.datetime(2500, 1, 1)
+MIN_TIMESTAMP = MIN_DATETIME.replace(tzinfo=dt.timezone.utc).timestamp()
+MAX_TIMESTAMP = MAX_DATETIME.replace(tzinfo=dt.timezone.utc).timestamp()
+
+# The "right/*" zones count leap seconds in POSIX timestamps, which makes
+# timestamps inconsistent with datetime arithmetic. They're only installed on
+# some systems.
+zoneinfos = st.timezones().filter(lambda tz: not tz.key.startswith("right/"))
+
+naive_datetimes = st.datetimes(min_value=MIN_DATETIME, max_value=MAX_DATETIME)
+aware_datetimes = st.datetimes(
+    min_value=MIN_DATETIME,
+    max_value=MAX_DATETIME,
+    timezones=st.just(dt.timezone.utc) | zoneinfos,
+)
+timestamps = st.floats(min_value=MIN_TIMESTAMP, max_value=MAX_TIMESTAMP)
+
+
+def datetime_to_ns(destination: dt.datetime) -> int:
+    # timedelta arithmetic is exact, unlike float timestamps.
+    return (destination - EPOCH_AWARE) // dt.timedelta(microseconds=1) * 1_000
+
+
+def timedelta_to_ns(delta: dt.timedelta) -> int:
+    return delta // dt.timedelta(microseconds=1) * 1_000
+
+
+@settings(deadline=None)
+@given(timestamp=timestamps)
+def test_travel_to_timestamp(timestamp):
+    expected_ns = round(timestamp * NANOSECONDS_PER_SECOND)
+    with time_machine.travel(timestamp, tick=False):
+        assert time.time_ns() == expected_ns
+        assert time.time() == expected_ns / NANOSECONDS_PER_SECOND
+
+
+@settings(deadline=None)
+@given(destination=aware_datetimes)
+def test_travel_to_aware_datetime(destination):
+    with time_machine.travel(destination, tick=False):
+        assert time.time_ns() == datetime_to_ns(destination)
+        now_utc = dt.datetime.now(dt.timezone.utc)
+        assert now_utc == destination
+        assert dt.datetime.now(destination.tzinfo) == now_utc
+
+
+@settings(deadline=None)
+@given(destination=naive_datetimes)
+def test_travel_to_naive_datetime_treated_as_utc(destination):
+    # In the default naive_mode (MIXED), naive datetimes are treated as UTC.
+    with time_machine.travel(destination, tick=False):
+        assert time.time_ns() == datetime_to_ns(
+            destination.replace(tzinfo=dt.timezone.utc)
+        )
+        assert dt.datetime.now(dt.timezone.utc).replace(tzinfo=None) == destination
+
+
+@settings(deadline=None)
+@given(
+    destination=st.dates(min_value=MIN_DATETIME.date(), max_value=MAX_DATETIME.date())
+)
+def test_travel_to_date(destination):
+    midnight = dt.datetime.combine(destination, dt.time(0, 0), tzinfo=dt.timezone.utc)
+    with time_machine.travel(destination, tick=False):
+        assert time.time_ns() == datetime_to_ns(midnight)
+        assert time.time() == midnight.timestamp()
+        now = dt.datetime.now(dt.timezone.utc)
+        assert now == midnight
+        assert now.date() == destination
+
+
+@settings(deadline=None)
+@given(destination=aware_datetimes)
+def test_travel_to_isoformat_string(destination):
+    with time_machine.travel(destination.isoformat(), tick=False):
+        assert time.time_ns() == datetime_to_ns(destination)
+
+
+@settings(deadline=None)
+@given(outer=timestamps, inner=timestamps)
+def test_travel_nested(outer, inner):
+    with time_machine.travel(outer, tick=False):
+        with time_machine.travel(inner, tick=False):
+            assert time.time_ns() == round(inner * NANOSECONDS_PER_SECOND)
+        assert time.time_ns() == round(outer * NANOSECONDS_PER_SECOND)
+
+
+@settings(deadline=None)
+@given(timestamp=timestamps)
+def test_travel_tick_monotonic(timestamp):
+    expected_ns = round(timestamp * NANOSECONDS_PER_SECOND)
+    with time_machine.travel(timestamp):
+        first = time.time_ns()
+        second = time.time_ns()
+        assert expected_ns <= first <= second
+        assert second - first < 10 * NANOSECONDS_PER_SECOND
+
+
+@settings(deadline=None)
+@given(
+    delta=st.timedeltas(
+        min_value=dt.timedelta(days=-18_000), max_value=dt.timedelta(days=18_000)
+    )
+)
+def test_shift_timedelta(delta):
+    start = dt.datetime(2020, 4, 29, tzinfo=dt.timezone.utc)
+    with time_machine.travel(start, tick=False) as traveller:
+        traveller.shift(delta)
+        assert time.time_ns() == datetime_to_ns(start) + timedelta_to_ns(delta)
+
+
+@settings(deadline=None)
+@given(
+    delta_seconds=st.integers(min_value=-(2**30), max_value=2**30)
+    | st.floats(min_value=-(2.0**30), max_value=2.0**30)
+)
+def test_shift_number(delta_seconds):
+    start = dt.datetime(2020, 4, 29, tzinfo=dt.timezone.utc)
+    expected_delta_ns = round(delta_seconds * NANOSECONDS_PER_SECOND)
+    with time_machine.travel(start, tick=False) as traveller:
+        traveller.shift(delta_seconds)
+        assert time.time_ns() == datetime_to_ns(start) + expected_delta_ns
+
+
+@settings(deadline=None)
+@given(first=timestamps, second=timestamps)
+def test_move_to(first, second):
+    with time_machine.travel(first, tick=False) as traveller:
+        assert time.time_ns() == round(first * NANOSECONDS_PER_SECOND)
+        traveller.move_to(second)
+        assert time.time_ns() == round(second * NANOSECONDS_PER_SECOND)
+
+
+@pytest.mark.skipif(
+    not hasattr(time, "tzset"), reason="Doesn't have tzset, so travel() can't set TZ"
+)
+@settings(deadline=None)
+@given(
+    # Past 2038, some platforms' time functions stop applying zones' POSIX DST
+    # rules, diverging from zoneinfo.
+    destination=st.datetimes(min_value=MIN_DATETIME, max_value=dt.datetime(2038, 1, 1)),
+    tz=zoneinfos,
+)
+def test_localtime_and_gmtime_match_datetime(destination, tz):
+    aware = destination.replace(tzinfo=tz)
+    with time_machine.travel(aware, tick=False):
+        seconds = time.time_ns() // NANOSECONDS_PER_SECOND
+
+        local = time.localtime()
+        expected_local = dt.datetime.fromtimestamp(seconds, tz)
+        assert (
+            local.tm_year,
+            local.tm_mon,
+            local.tm_mday,
+            local.tm_hour,
+            local.tm_min,
+            local.tm_sec,
+        ) == (
+            expected_local.year,
+            expected_local.month,
+            expected_local.day,
+            expected_local.hour,
+            expected_local.minute,
+            expected_local.second,
+        )
+        utcoffset = expected_local.utcoffset()
+        assert utcoffset is not None
+        assert local.tm_gmtoff == int(utcoffset.total_seconds())
+
+        utc = time.gmtime()
+        expected_utc = dt.datetime.fromtimestamp(seconds, dt.timezone.utc)
+        assert (
+            utc.tm_year,
+            utc.tm_mon,
+            utc.tm_mday,
+            utc.tm_hour,
+            utc.tm_min,
+            utc.tm_sec,
+        ) == (
+            expected_utc.year,
+            expected_utc.month,
+            expected_utc.day,
+            expected_utc.hour,
+            expected_utc.minute,
+            expected_utc.second,
+        )
+
+
+@given(timestamp=timestamps)
+def test_extract_timestamp_tzname_number(timestamp):
+    assert time_machine.extract_timestamp_tzname(timestamp) == (
+        round(timestamp * NANOSECONDS_PER_SECOND),
+        None,
+    )
+    int_timestamp = int(timestamp)
+    assert time_machine.extract_timestamp_tzname(int_timestamp) == (
+        int_timestamp * NANOSECONDS_PER_SECOND,
+        None,
+    )
+
+
+@given(destination=naive_datetimes, tz=zoneinfos)
+def test_extract_timestamp_tzname_zoneinfo_datetime(destination, tz):
+    aware = destination.replace(tzinfo=tz)
+    timestamp_ns, tzname = time_machine.extract_timestamp_tzname(aware)
+    assert timestamp_ns == datetime_to_ns(aware)
+    assert tzname == tz.key
+
+
+@given(destination=naive_datetimes)
+def test_extract_timestamp_tzname_utc_datetime(destination):
+    aware = destination.replace(tzinfo=dt.timezone.utc)
+    timestamp_ns, tzname = time_machine.extract_timestamp_tzname(aware)
+    assert timestamp_ns == datetime_to_ns(aware)
+    assert tzname == "UTC"
+
+
+@given(
+    delta=st.timedeltas(
+        min_value=dt.timedelta(days=-1_000), max_value=dt.timedelta(days=1_000)
+    )
+)
+def test_extract_timestamp_tzname_timedelta(delta):
+    delta_ns = timedelta_to_ns(delta)
+    before_ns = time.time_ns()
+    timestamp_ns, tzname = time_machine.extract_timestamp_tzname(delta)
+    after_ns = time.time_ns()
+    assert tzname is None
+    assert before_ns + delta_ns <= timestamp_ns <= after_ns + delta_ns

--- a/tox.ini
+++ b/tox.ini
@@ -21,3 +21,7 @@ commands =
       -m pytest {posargs:tests}
 dependency_groups =
     test
+
+[testenv:py313t]
+dependency_groups =
+    test-base

--- a/uv.lock
+++ b/uv.lock
@@ -410,6 +410,79 @@ wheels = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.165.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/6f/324d76c305075036519f63f986e81e8c3f7d0a3510eb88510bc407967ab0/hypothesis-6.165.0.tar.gz", hash = "sha256:b54e86cb1d7d049eb934e7843f179889252263b24290ebd38549466c9c9351d9", size = 493017, upload-time = "2026-08-02T00:20:26.755Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/f2/c85859811281475dc3dddd628979be6683ea5012494316250d29a6d9d72a/hypothesis-6.165.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dda3707dfdfdc1397b7489ecb81534f47f22f98d468c51c92d591d6967c58b29", size = 772599, upload-time = "2026-08-02T00:19:34.099Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/05/a28b2ad55773b36812a1ad6f88d55b051ef324c606efa880c78ccceefbd6/hypothesis-6.165.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a384468744915435a25a9f2dcd0a74e9f78f8d56cb51f5ea1c1c4973bd40bd5b", size = 768129, upload-time = "2026-08-02T00:19:38.326Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ab/3567e7f5aa16319ee9e0fb014e588149e4ef6080028fc07f2748deed9f0d/hypothesis-6.165.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d65562b9866a5a4be4c731bd4018152861997675b92ed6d0f29e925999928f9a", size = 1097411, upload-time = "2026-08-02T00:18:58.073Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/5d/312c3b3831183668beff6974a290390f2327846e3bd0baa44f116eecc1bc/hypothesis-6.165.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b402560b0463e643170d904a5987f61bc388718f7b48d4521b7a5b22e6a27019", size = 1125993, upload-time = "2026-08-02T00:19:36.967Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/39/f47f529c41853d56c0ceac5dcb69a6ffae43d1367877575b2b57c9c60fb3/hypothesis-6.165.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1e134b573c18fb7e79f915ccad3585f81c0b92ff7cf89f6c0b0d966a5ac5156", size = 1146830, upload-time = "2026-08-02T00:19:07.51Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/9f/4d613a35b834c602499746c0d8036aa5c0a9b2c7a23f294292a132a352db/hypothesis-6.165.0-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:22d3b846796593117a1227b6d9e8c0c1269ce6327fa6345fb50f24a038e1a0c1", size = 1102233, upload-time = "2026-08-02T00:20:25.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/69/f11136ed8feac210f247dcad53c9a5cbcf067ae42d4d51c9ba61640aafc1/hypothesis-6.165.0-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:47d419899477ed35704d4f90f82aadbaa50080d7d0ff33db6727bbc4b1c3956d", size = 1138969, upload-time = "2026-08-02T00:19:32.587Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/ad/dbd5e97bf214993033ddb93f199d99410be33d7f997996c8dc2f6255edfc/hypothesis-6.165.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:71721d9de23b60f5436a1b8b8fddccd6df606efbb406f36254195089974518ee", size = 1271210, upload-time = "2026-08-02T00:20:16.318Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f1/db4ecb5f01cebc19ccfe8b4b170fa211f2cfd22946ca8c9f4007eba59140/hypothesis-6.165.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:584734f6380f1965498bff2f72af307c182b3398a9c4e1b2f31e43dd1aa9c922", size = 1399053, upload-time = "2026-08-02T00:19:55.646Z" },
+    { url = "https://files.pythonhosted.org/packages/68/15/205570c5f3935e074b93c7b6bda87889039d59ba39426c70e7c93bfdc939/hypothesis-6.165.0-cp310-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:61d99c493f759809e64dbe544a47948537460c9f03f916d66291bb63965fc91a", size = 1271824, upload-time = "2026-08-02T00:19:52.519Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5e/d77c9cf07bd4a7b2c386cc7f8eba6c614d62723e830d0366ca2381f35cb1/hypothesis-6.165.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:68629657d49b7dba3f061d0224441df068c0c03e7a17efc278782f637d810db7", size = 1313877, upload-time = "2026-08-02T00:19:13.765Z" },
+    { url = "https://files.pythonhosted.org/packages/38/46/6e7f945c465b94951bb91bbc50cb1dc847a749d32e1e5efd6e47a5a7747b/hypothesis-6.165.0-cp310-abi3-win32.whl", hash = "sha256:90633ec15635385723d29a1e9b6fe8f63e17b33641353c6b58fc7d277672ef29", size = 658400, upload-time = "2026-08-02T00:19:31.133Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c5/81519854c72e1f57ec44df6484f6a34f1789f1fc4c0b8647d2fd1e28d25c/hypothesis-6.165.0-cp310-abi3-win_amd64.whl", hash = "sha256:bab53228c59978c74c87dba27db4656feaf991f20db5242ea263531477227247", size = 664538, upload-time = "2026-08-02T00:20:02.436Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d3/e98873c290413a4c76f80941910e308341e4970d915789ac6e6963abb523/hypothesis-6.165.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:3eb93f9b01ac3093a6222ac1abbf2e38a467f3d9d58ba0ba7b7edd5c6dbd4a04", size = 773299, upload-time = "2026-08-02T00:19:54.043Z" },
+    { url = "https://files.pythonhosted.org/packages/91/49/3fcea93d1a3fb33d527d1210d416dc3c3a262bc5243f13b670960f7c9bda/hypothesis-6.165.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9577cef884fba9c7dd53c5621ac7998a36c0ab9305e6e144ea68888450a617e0", size = 769041, upload-time = "2026-08-02T00:19:06.258Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/60/9f0034d254d7eff2dc6c0866196a7d35578935b31a90b018c8e6fa0d6c4e/hypothesis-6.165.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d133114ff723ab9cd1ae72407ae1174061d78a25992196ab54e2e7a8fd7f3e8", size = 1097899, upload-time = "2026-08-02T00:19:18.122Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/24/17342e790dec9676ddae9cbba85ef5fc1df61ce929071dbf42cee40aa739/hypothesis-6.165.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:23764c6b64b60cb160ddc2aaefccb505abe234d2a82fc30ea75d28e94ecab44a", size = 1147426, upload-time = "2026-08-02T00:20:07.675Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/35/38a6223e439457954cbec215e1f2605ecacd2d34f40fb4df7cfcce7b3c11/hypothesis-6.165.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b37a9736395c2bc6a6f6ad42abb7bcaf935f5926ff9f688218eb05547d92927d", size = 1271852, upload-time = "2026-08-02T00:19:05.123Z" },
+    { url = "https://files.pythonhosted.org/packages/31/59/1bf66e2cd5c675c719f8531f82290aa7356195e33a26b9963e0c45ba793e/hypothesis-6.165.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:33b0f9ad5e9c86b80568b58af3710fdfd838a656d3500a050216238733235752", size = 1314195, upload-time = "2026-08-02T00:19:11.188Z" },
+    { url = "https://files.pythonhosted.org/packages/80/21/7be5f575c3b92e12aeb9c08c6dc9ad71c7f55f428fd9fb9e2b378bea15e0/hypothesis-6.165.0-cp310-cp310-win_amd64.whl", hash = "sha256:077756e2e648292aa5e181b1556eb4744720f7829aa7a810585fb90b543cc6fa", size = 664421, upload-time = "2026-08-02T00:19:16.651Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b4/ce9cfc632c1b77560b22971e93fe6c6cff34eee553aa6ca1ad3a808296f0/hypothesis-6.165.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:d71abdac3786725b3af5657024b00f8cfc690e56a8ba5020fd693f2d4339bcc6", size = 773089, upload-time = "2026-08-02T00:20:11.05Z" },
+    { url = "https://files.pythonhosted.org/packages/16/a6/e5203ff1eddf77439435b01e646941ca8b172ea402dfb35e921b9f1da1f7/hypothesis-6.165.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ddf924a80fc9b8cbd3bf31282821111be30e0ea5262c755fff861b827c9667d7", size = 768849, upload-time = "2026-08-02T00:19:15.008Z" },
+    { url = "https://files.pythonhosted.org/packages/26/f4/b6ee0d48ee9043f9d689ee573e5f4093e1a6276d5c59a8e8fca70cef278d/hypothesis-6.165.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4acd5f4e33afe297262bc8ae017d800f76fbeb6c8ec6fcb8885f210781fe826", size = 1097739, upload-time = "2026-08-02T00:19:47.251Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3e/ae3197c6e4625e74a88100e21ae8c20f112d4dbf0e100b5deaf1a5a890a8/hypothesis-6.165.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1d4b41dfc0e43533ef8e1525cd5084f880d633d4dec512bb63d3d33766bad288", size = 1147192, upload-time = "2026-08-02T00:19:09.936Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/3b/e76d981d4d1cb47963db2a658ae09fea60f9806cf402477ff5c3088404ae/hypothesis-6.165.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:121ca3e24c74bbed3cb9841ef37d25535fa32ec4708a252ef1a76516d35ccda8", size = 1271565, upload-time = "2026-08-02T00:19:26.951Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/c4/26105448321ca3363494bd7a660bf6511461afb7cc90b4d99f0dc78b7843/hypothesis-6.165.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8f7a440ef9f8319d26998e89ee83474ce9accb34eca4321e480ad3d2fbd74622", size = 1314212, upload-time = "2026-08-02T00:18:56.873Z" },
+    { url = "https://files.pythonhosted.org/packages/50/ed/70377905d6934cd5387cf027480c683240bf3e6c2c7d2208c82e16af2bdb/hypothesis-6.165.0-cp311-cp311-win_amd64.whl", hash = "sha256:d6d634e0e2ae2e367ea54180c0c654bd0ca756204cdec2473e01ebab2eaad793", size = 664291, upload-time = "2026-08-02T00:19:02.908Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1e/dd8e7c7cfd7635f632eba381f89dfbb9af77dc55fc5a11a754f0c0fba1a0/hypothesis-6.165.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:6942d6a0002092c9a1166915d26a3257c17da4b8c76859c9841b84a21a572262", size = 774175, upload-time = "2026-08-02T00:19:45.731Z" },
+    { url = "https://files.pythonhosted.org/packages/62/17/84b4102defda7916512badf2741b203688cb4236e6be10bf656997b9255d/hypothesis-6.165.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:20a17a11eeb3816b3d4c9576d4d9b44a985bf062ae232d0fad9a2e5c16b35a6b", size = 765771, upload-time = "2026-08-02T00:20:19.735Z" },
+    { url = "https://files.pythonhosted.org/packages/98/13/5f3a0f944286dc2913e9c84a788213e952d9e94b806e53c69bddce71eef9/hypothesis-6.165.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c2d5018013480fe207408e0d7c04244c46a7113c1c2aef779cbe17e1f8750988", size = 1096190, upload-time = "2026-08-02T00:19:28.44Z" },
+    { url = "https://files.pythonhosted.org/packages/34/87/11f9386bffecf9bbc13f459f308a844a512a3f34354cb8c3087f0733190a/hypothesis-6.165.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:504feb1f67bd1e6c83d42982f9f80a6d11acb164cc11519d4abf2e7479394be2", size = 1146237, upload-time = "2026-08-02T00:20:05.906Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ac/f24008063d2ed5eca2a8f59286849360dcf8c821a241e3553229f3d2d700/hypothesis-6.165.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:eff69d0c3ad00fe82f06420c8d13c33b86db24636c96ac457cbd9a5a588f6e88", size = 1269013, upload-time = "2026-08-02T00:19:42.717Z" },
+    { url = "https://files.pythonhosted.org/packages/44/43/b5ba1be7cebe0ca1c320e188a35761050cc933b8563c9cff0ce8d2d81518/hypothesis-6.165.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db118ef2c469fe607ac617a15ccc8bc0e05f27b866c1d923c963d9edd3e4b7e1", size = 1313226, upload-time = "2026-08-02T00:20:17.954Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c3/70a6f3ce669616b78adfd39bcb78cbc88e68bd1a6f670eb5b88273ae7cec/hypothesis-6.165.0-cp312-cp312-win_amd64.whl", hash = "sha256:f16f8fd1ca5d1a080a360bb37eee73f3fecf3ddabdcec979ae01b76ed895e777", size = 661691, upload-time = "2026-08-02T00:19:44.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/d4/3418ba26110b6c29e866bf1baa5b2d447827d00811e181be12ce08aebb9c/hypothesis-6.165.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:82385ff61d309b77097580e7200dc3e038f5eb78d3fe1a4aa0d110e5f1afa9df", size = 774071, upload-time = "2026-08-02T00:19:23.829Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/f4/d89ab31f52ecbcc8328d25add616b9d530a5f76003ae4ac5a9bfc7080db5/hypothesis-6.165.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2e7b277f56786ec0730cd3e428ea3611b59e3ecae3382553f3fea958e8c2c25f", size = 765718, upload-time = "2026-08-02T00:19:35.595Z" },
+    { url = "https://files.pythonhosted.org/packages/06/13/10a32a1e3ba78c3b66281aa1e2764269765ad058fb977d6b62dc6679e63a/hypothesis-6.165.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c73d3d4e57a00122a2657ae400b8d066fd0cfa1621c6aa3a6b38dd4b4c268035", size = 1096108, upload-time = "2026-08-02T00:20:09.316Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/87/f16688e373b982f6fb3bf0edd4aa42eb731e8a758582052ec1bfe7c93b30/hypothesis-6.165.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:89b41b1daa93c9e544cdad636ec87d4a45169d1922c6aff80fa282cd1edeeb74", size = 1146051, upload-time = "2026-08-02T00:19:49.262Z" },
+    { url = "https://files.pythonhosted.org/packages/af/2f/a560867b9be5c908e379c4a308a7e44b8082e18faf4096b5a0708497ba30/hypothesis-6.165.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3b2fef387ec63e60c85db6c4fc95b07a6b7f35c971381997c862d309af9e1e4b", size = 1269056, upload-time = "2026-08-02T00:20:21.588Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/60/35d03cf44a7803622fa39121e8c674253175890a9b081ae0b8137a1d32ef/hypothesis-6.165.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c681bdf0036ba7923b7c4225937a48e12db7029a286b51ddc03d9b08afe2f040", size = 1312946, upload-time = "2026-08-02T00:19:12.547Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a9/1b587430b9ec6576fdafa102657d70d456b5694db45ee21fba88aa0c8ea1/hypothesis-6.165.0-cp313-cp313-win_amd64.whl", hash = "sha256:29edc5a08334985cea55afe6ab564c147e4b804179265eb303c9ed8e494c211b", size = 661683, upload-time = "2026-08-02T00:19:29.812Z" },
+    { url = "https://files.pythonhosted.org/packages/04/b5/4aab253b312334cf2d475ff8a0a2136eef6af091f9f33ce37275864437fd/hypothesis-6.165.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:6536572500e926ec8128069fda8bbcd13019484e0d5c1b4a82b6ef50417bcfbe", size = 774311, upload-time = "2026-08-02T00:19:41.234Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/97/85363607d7303080d8e48277d5ff56e7fb2ad5792f5fe97e66e16f5fcce0/hypothesis-6.165.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d86c82a7796d124643d146eef00d873d336d1792a682096358bfee82dde34879", size = 765857, upload-time = "2026-08-02T00:19:08.724Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/80/415bd4b25fa2acc07228f7f86a438cc31d1caccf0c5ab49210b32e895990/hypothesis-6.165.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b646658e06b72b2bd2396ffe7a08a0edcfa799f649db22e1d59cc8bd5d174e6", size = 1096607, upload-time = "2026-08-02T00:20:04.23Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f2/95786f14932fc76273829e20d43185c4fe9a30b5930108895b0b805566ac/hypothesis-6.165.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e0fb8c29ad35fefa25f38c0bbc1b2eee28d1e4a796a977491445b05d11cb1ae", size = 1146225, upload-time = "2026-08-02T00:19:01.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/90/9284f79a7e03f8185433dfd4eb2eef64a2766e160a82f3b108d35cd5d0e9/hypothesis-6.165.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a998176a8cf1b1914c5cf8beef0b74d0065482aa2a4d0c708e63216245d968c7", size = 1269388, upload-time = "2026-08-02T00:20:12.785Z" },
+    { url = "https://files.pythonhosted.org/packages/90/d6/e91cbc7e5c7b740ba8e5195d114f87281b4ee36f534c488aa06a4ef2eba4/hypothesis-6.165.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:510518cb4259916685151aa41c44a3999534c35eee921dcfbc4ea4e4631bd6d2", size = 1313262, upload-time = "2026-08-02T00:19:00.584Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/4f/3c5350ef157e039c1624f16495b35d7930c63946d7b07b8c2fe80537f8e8/hypothesis-6.165.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:1f786c76577ec0639390baf0b4c12491fa909131e41de76078a4a886ccd40661", size = 605819, upload-time = "2026-08-02T00:19:50.814Z" },
+    { url = "https://files.pythonhosted.org/packages/66/46/59cb3bd95346ba9626b72af40cff43a95d0b4554bb5f4bdc59cc8724924b/hypothesis-6.165.0-cp314-cp314-win_amd64.whl", hash = "sha256:0bbc39067ba06514fc0c934c34863492403ffc708a07d6a506b9460058550127", size = 661568, upload-time = "2026-08-02T00:20:14.452Z" },
+    { url = "https://files.pythonhosted.org/packages/30/d3/bcda5097a4535b8bb8f3ca94cce103e59149db16923732d06121c9f23a56/hypothesis-6.165.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:38222e75db0f348c8ddaab10903fc3971846f11363e64efdb4794f34aed6494f", size = 772867, upload-time = "2026-08-02T00:19:19.441Z" },
+    { url = "https://files.pythonhosted.org/packages/74/06/3f275d4c2f6977133a2ad1f0c22bc75d7e3f86bc2f279c33228f4a2230e4/hypothesis-6.165.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:01c485be9970a40935b2d2f277d751d60aaa910e4dc5ec337828e80c9c8dfdc8", size = 764394, upload-time = "2026-08-02T00:19:22.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/82/3d3bb9b971946369bf4574595ed0291c49378b6ff372c169fe0da07c036a/hypothesis-6.165.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6bcb354b9bfc7dcf5fbcb559cd5b3f48e0d92a4f1f6e5fbcf9fbc8cc82e51e61", size = 1095202, upload-time = "2026-08-02T00:19:25.331Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/a4/93c86242ef646f798afde2f406c23b077e86c4bd39d304baa7ef7b31df81/hypothesis-6.165.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51dbf9192af532f9081c90f00afb0a7684da5543ccae8ab9507da269b6702ccf", size = 1145134, upload-time = "2026-08-02T00:20:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ec/b0bb70f92bea56be91e5ea431bf0af6a3fd3fd9a70b9106ccc05510d34af/hypothesis-6.165.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:70dd766e80e575580e635d6661f945ef07055e66075a93fd489d53611cb5a7a1", size = 1267624, upload-time = "2026-08-02T00:19:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9b/d8bfd5410cae98b39145b817304316dc74ece187e03e273b271d1a769dfb/hypothesis-6.165.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5e811db36037576b277d8fc390d3fcb94d7924ec861d05adb0cdfd8e3ea86822", size = 1312004, upload-time = "2026-08-02T00:19:39.823Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/55/0e2f19c6d75d04f2604ebb36bc561a120fc9173a694130b853a248586860/hypothesis-6.165.0-cp314-cp314t-win_amd64.whl", hash = "sha256:7a14b7905e4aad404c820bd01f8a1272042123233edf04149b847db2c5076584", size = 661693, upload-time = "2026-08-02T00:18:59.486Z" },
+    { url = "https://files.pythonhosted.org/packages/71/12/90cd963d686df240b6af82f627fc4dda3d579fc336bd56f2475dca478821/hypothesis-6.165.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:1c228b2fdd018e56a50c5a18e003fa8d139374321f2e79739c19ffcc1138b6b3", size = 773967, upload-time = "2026-08-02T00:19:58.959Z" },
+    { url = "https://files.pythonhosted.org/packages/23/72/25ad50dcd40978ca8b27f952a7532cbf4c15ed9cf26e93df457dafe9823a/hypothesis-6.165.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:66376231b678675abfd670a6df1bb59c4e760c894411d4333dd48126072fc0a8", size = 769854, upload-time = "2026-08-02T00:18:54.669Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f2/c2fa2b97323315b31582bf922848e1a071323937ec39299bc1d1ee7a3222/hypothesis-6.165.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b407d4441af3f0c807a0904ec9d4c7cb71a5612961f2a6a23475eeb34329392d", size = 1098711, upload-time = "2026-08-02T00:19:57.433Z" },
+    { url = "https://files.pythonhosted.org/packages/23/e2/6eaa36f5fa1cdde9a8222fd120ee4815e6fdc43f16ca99b3569a36ce961c/hypothesis-6.165.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06970b389b442740bb6aece39bda3c925d7ac5c23d9bcdcae9f5b2c6aa3002b0", size = 1148501, upload-time = "2026-08-02T00:20:23.334Z" },
+    { url = "https://files.pythonhosted.org/packages/76/de/c85cc3ab0e8a807637d349e1600f55e0d3451da97d8639f479aa37639752/hypothesis-6.165.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:1748c1e6db507023cda4bd21d7706ad17b9339fb99232676e0ddbb213ff976e3", size = 665371, upload-time = "2026-08-02T00:19:04.017Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.18"
 source = { registry = "https://pypi.org/simple" }
@@ -663,6 +736,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
 name = "soupsieve"
 version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -886,6 +968,14 @@ docs = [
 test = [
     { name = "coverage", extra = ["toml"] },
     { name = "freezegun" },
+    { name = "hypothesis" },
+    { name = "pytest" },
+    { name = "pytest-randomly" },
+    { name = "python-dateutil" },
+]
+test-base = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "freezegun" },
     { name = "pytest" },
     { name = "pytest-randomly" },
     { name = "python-dateutil" },
@@ -907,6 +997,14 @@ docs = [
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
 ]
 test = [
+    { name = "coverage", extras = ["toml"] },
+    { name = "freezegun" },
+    { name = "hypothesis" },
+    { name = "pytest", specifier = ">=9" },
+    { name = "pytest-randomly" },
+    { name = "python-dateutil" },
+]
+test-base = [
     { name = "coverage", extras = ["toml"] },
     { name = "freezegun" },
     { name = "pytest", specifier = ">=9" },


### PR DESCRIPTION
Add property-based tests covering:

1. `travel()` destinations (timestamps, aware/naive datetimes, dates, ISO strings)
2. nesting
3. tick monotonicity
4. `shift()`
5. `move_to()`
6. `extract_timestamp_tzname()`
7. cconsistency of `time.localtime()`/`gmtime()` with `datetime` conversions

All assertions on the travelled-to instant are exact, relying on the integer nanosecond destination handling.