### PR TITLE
Remove sphinx-build-compatibility

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,7 +5,6 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 from __future__ import annotations
 
-import os
 import sys
 from pathlib import Path
 
@@ -42,8 +41,6 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx_copybutton",
 ]
-if os.environ.get("READTHEDOCS") == "True":
-    extensions.append("sphinx_build_compatibility.extension")
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -70,6 +67,9 @@ html_theme_options = {
         "admonition-font-size": "100%",
         "admonition-title-font-size": "100%",
     },
+    "source_repository": "https://github.com/adamchainz/time-machine/",
+    "source_branch": "main",
+    "source_directory": "docs/",
 }
 
 # -- Options for LaTeX output ------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ test = [
 docs = [
   "furo>=2024.8.6",
   "sphinx>=7.4.7",
-  "sphinx-build-compatibility",
   "sphinx-copybutton>=0.5.2",
 ]
 build = [
@@ -76,7 +75,6 @@ test-base = [
 
 [tool.uv]
 dependency-groups.build = { requires-python = ">=3.14" }
-sources.sphinx-build-compatibility = { git = "https://github.com/readthedocs/sphinx-build-compatibility", rev = "4f304bd4562cdc96316f4fec82b264ca379d23e0" }
 
 [tool.cibuildwheel]
 build = [

--- a/uv.lock
+++ b/uv.lock
@@ -862,17 +862,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sphinx-build-compatibility"
-version = "0.0.1"
-source = { git = "https://github.com/readthedocs/sphinx-build-compatibility?rev=4f304bd4562cdc96316f4fec82b264ca379d23e0#4f304bd4562cdc96316f4fec82b264ca379d23e0" }
-dependencies = [
-    { name = "requests" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-]
-
-[[package]]
 name = "sphinx-copybutton"
 version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -962,7 +951,6 @@ docs = [
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "sphinx-build-compatibility" },
     { name = "sphinx-copybutton" },
 ]
 test = [
@@ -993,7 +981,6 @@ build = [{ name = "cibuildwheel", marker = "python_full_version >= '3.14'", spec
 docs = [
     { name = "furo", specifier = ">=2024.8.6" },
     { name = "sphinx", specifier = ">=7.4.7" },
-    { name = "sphinx-build-compatibility", git = "https://github.com/readthedocs/sphinx-build-compatibility?rev=4f304bd4562cdc96316f4fec82b264ca379d23e0" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
 ]
 test = [


### PR DESCRIPTION
The extension is [explicitly a temporary workaround](https://github.com/readthedocs/sphinx-build-compatibility) for Read the Docs no longer injecting variables into Sphinx’s html_context. The only ones Furo used were those behind the “edit this page” links, which it supports natively through theme options.
