### PR TITLE
Publish wheels for Python 3.15

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,10 @@ Changelog
 Unreleased
 ----------
 
+* Publish wheels for Python 3.15.
+
+  Thanks to Edgar Ramírez Mondragón in `PR #655 <https://github.com/adamchainz/time-machine/pull/655>`__.
+
 * Fix a reference leak in the patched ``datetime.datetime.utcnow()`` that occurred when its Python 3.12+ ``DeprecationWarning`` was raised as an error, such as under ``-W error``.
   Each such call leaked a reference to the active traveller object.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,8 @@ dependency-groups.build = { requires-python = ">=3.14" }
 
 [tool.cibuildwheel]
 build = [
+  "cp315-*",
+  "cp315t-*",
   "cp314-*",
   "cp314t-*",
   "cp313-*",

--- a/uv.lock
+++ b/uv.lock
@@ -181,7 +181,7 @@ wheels = [
 
 [[package]]
 name = "cibuildwheel"
-version = "4.1.1"
+version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bashlex" },
@@ -194,9 +194,9 @@ dependencies = [
     { name = "packaging" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/56/63/7c2e4e3ef8c133a2a7d167b031471b8bd8e0674edde8e5f8622f8f5965e7/cibuildwheel-4.1.1.tar.gz", hash = "sha256:30ee78f134a8273b2f128ffb8c84bce577b9352af30e8ecf412cdf71bb3844c2", size = 454766, upload-time = "2026-07-24T20:33:18.539Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/b5/68696cc0023dcde3dc5f9f94f7aa3d319fe8f47ad80ba12224f90c837fcb/cibuildwheel-4.2.0.tar.gz", hash = "sha256:a018495ace49e84422ef89c01891439ee0fd00cebd3758b9a879415ff4892d97", size = 455959, upload-time = "2026-08-05T02:25:04.579Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/21/6f157a49f86163aef5c5aa18e0e90a67a3d70428f4a66710440339a4ae0e/cibuildwheel-4.1.1-py3-none-any.whl", hash = "sha256:3d669d6fa20a3e70c33ea4d3128a7f78706dc22b6f40d2cc028b12fc80580276", size = 167204, upload-time = "2026-07-24T20:33:17.102Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ef/217ba042d73ac2d7500794993069cde78551f538a75c67626929a8587f80/cibuildwheel-4.2.0-py3-none-any.whl", hash = "sha256:4c7d6fc52cf5422c944aed86bc531f15e2279b91ff2c5e9e6fed9d6e3eefc635", size = 167818, upload-time = "2026-08-05T02:25:02.833Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Support was added in #631 but the cibw config was not updated.