### PR TITLE
Fix reference leak in `utcnow()` when `DeprecationWarning` raised as error

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Fix a reference leak in the patched ``datetime.datetime.utcnow()`` that occurred when its Python 3.12+ ``DeprecationWarning`` was raised as an error, such as under ``-W error``.
+  Each such call leaked a reference to the active traveller object.
+
+  `PR #656 <https://github.com/adamchainz/time-machine/pull/656>`__.
+
 3.3.1 (2026-08-04)
 ------------------
 

--- a/src/_time_machine.c
+++ b/src/_time_machine.c
@@ -358,6 +358,7 @@ _time_machine_utcnow(PyObject *cls, PyObject *args)
 
     // Warn as the original function would, pointing at its caller.
     if (_time_machine_warn_utcnow_deprecated(1) < 0) {
+        Py_DECREF(traveller);
         return NULL;
     }
 

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -174,6 +174,19 @@ def test_datetime_utcnow_deprecation_warning():
     assert_warned_here(records[0])
 
 
+@py_utcnow_deprecated
+def test_datetime_utcnow_deprecation_error_no_reference_leak():
+    with time_machine.travel(EPOCH):
+        traveller = time_machine.traveller_stack[-1]
+        expected = sys.getrefcount(traveller)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            for _ in range(10):
+                with pytest.raises(DeprecationWarning):
+                    dt.datetime.utcnow()
+        assert sys.getrefcount(traveller) == expected
+
+
 @py_utcnow_not_deprecated
 def test_datetime_utcnow_no_deprecation_warning():
     with time_machine.travel(EPOCH), warnings.catch_warnings():


### PR DESCRIPTION
In `_time_machine_utcnow()`, when the Python 3.12+ `utcnow()` `DeprecationWarning` was escalated to an error, such as under `-W error`, the early return skipped `Py_DECREF(traveller)`, leaking a reference to the active traveller on every call.