### PR TITLE
Extend Migration CLI to cover freezegun's pytest plugin patterns

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,7 @@ repos:
   hooks:
   - id: mypy
     additional_dependencies:
+    - hypothesis==6.165.2
     - pytest==7.1.2
     - types-python-dateutil
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,22 @@ Unreleased
 
   `PR #656 <https://github.com/adamchainz/time-machine/pull/656>`__.
 
+* Extend the :ref:`Migration CLI <migration-cli>` to migrate patterns from freezegun’s pytest plugins, pytest-freezegun and pytest-freezer: the ``freezer`` fixture and the ``pytest.mark.freeze_time`` marker.
+  Also make it migrate ``freeze_time()`` context managers that bind the result with ``as``, including converting ``tick()`` method calls to ``shift()``.
+
+  `PR #658 <https://github.com/adamchainz/time-machine/pull/658>`__.
+  Thanks to Javier Buzzi for the initial work in `PR #562 <https://github.com/adamchainz/time-machine/pull/562>`__.
+
+* Fix the :ref:`Migration CLI <migration-cli>` to handle trailing commas in ``freeze_time()`` calls when adding ``tick=False``.
+  Previously, it produced invalid syntax, like ``travel("2023-01-01",, tick=False)``.
+
+  `PR #658 <https://github.com/adamchainz/time-machine/pull/658>`__.
+
+* Fix the :ref:`Migration CLI <migration-cli>` to not indent imports kept from a rewritten from-import when the import doesn’t start its line, such as after ``if True:`` on one line.
+  Previously, the kept import gained leading whitespace, producing invalid syntax.
+
+  `PR #658 <https://github.com/adamchainz/time-machine/pull/658>`__.
+
 3.3.1 (2026-08-04)
 ------------------
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -88,6 +88,26 @@ The changes the tool makes are:
 * In function decorators, class decorators, and context managers: ``freeze_time(...)`` -> ``travel(...)``.
   This change is applied only when ``freeze_time()`` is called with a single positional argument and up to one keyword argument, ``tick``.
   If ``tick`` is passed, it is kept as-is, otherwise it is replaced with ``tick=False`` (matching freezegun’s default behaviour).
-  In context managers, it’s only applied when the result isn’t assigned to a variable with ``as``.
+
+* In context managers that bind the result with ``as``, additionally: calls of the bound variable’s ``tick()`` method -> ``shift()``, with freezegun’s default delta of one second made explicit, for example ``ft.tick()`` -> ``ft.shift(1)``.
+  Calls of the ``move_to()`` method are left unchanged, since it behaves the same in both libraries.
+  These changes are only applied when the bound variable is used solely for ``move_to()`` calls and ``tick()`` calls as statements, since ``tick()`` returns the new time whilst ``shift()`` returns ``None``, and other freezegun attributes have no equivalent on the object that ``travel()`` yields.
+
+* The ``pytest.mark.freeze_time`` marker from `pytest-freezegun <https://pypi.org/project/pytest-freezegun/>`__ or `pytest-freezer <https://pypi.org/project/pytest-freezer/>`__: ``@pytest.mark.freeze_time(...)`` -> ``@pytest.mark.time_machine(...)``, the marker from time-machine’s :doc:`pytest plugin <pytest_plugin>`.
+  This migration uses the same argument handling as for ``freeze_time()`` calls.
+
+* The ``freezer`` fixture from pytest-freezegun or pytest-freezer -> the ``time_machine`` fixture from time-machine’s pytest plugin.
+  In functions with an argument named ``freezer``, the argument is renamed to ``time_machine`` and calls of the fixture’s methods are migrated:
+
+  * ``freezer.move_to(...)`` -> ``time_machine.move_to(..., tick=False)``, again matching freezegun’s default behaviour.
+    ``tick=False`` isn’t added in functions using a migrated ``pytest.mark.freeze_time`` marker, since there the fixture inherits the ``tick`` behaviour from the marker.
+
+  * ``freezer.tick()`` -> ``time_machine.shift(1)``, as for context manager variables, again only for calls as statements.
+
+  Other uses of ``freezer`` are left unchanged, for your linter to flag.
+  ``freeze_time()`` calls within such functions are also left unchanged, because the renamed argument shadows the ``time_machine`` module.
+
+  Note that the ``time_machine`` fixture doesn’t mock the time until its ``move_to()`` method is called, unlike ``freezer``, which mocks from the start of the test.
+  Migrated tests that relied on that, for example by calling ``freezer.tick()`` before any ``move_to()``, will need manual adjustment.
 
 The tool is open to extension to cover other compatible changes—PRs welcome!

--- a/src/time_machine/cli.py
+++ b/src/time_machine/cli.py
@@ -9,6 +9,7 @@ from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from functools import partial
 
 from tokenize_rt import (
+    NON_CODING_TOKENS,
     UNIMPORTANT_WS,
     Offset,
     Token,
@@ -129,15 +130,48 @@ def fixup_dedent_tokens(tokens: list[Token]) -> None:  # pragma: no cover
 TokenFunc = Callable[[list[Token], int], None]
 
 
+class FreezerFunction:
+    """
+    Details of a function taking pytest-freezegun / pytest-freezer’s
+    ``freezer`` fixture as an argument.
+    """
+
+    __slots__ = ("lineno", "end_lineno", "marker_seen")
+
+    def __init__(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef, *, marker_seen: bool
+    ) -> None:
+        assert node.end_lineno is not None
+        self.lineno = node.lineno
+        self.end_lineno = node.end_lineno
+        self.marker_seen = marker_seen
+
+
+class TravellerVar:
+    """
+    Details of a variable bound with ``as`` to a migrated freeze_time()
+    context manager.
+    """
+
+    __slots__ = ("name", "lineno", "end_lineno")
+
+    def __init__(self, name: str, node: ast.With) -> None:
+        assert node.end_lineno is not None
+        self.name = name
+        self.lineno = node.lineno
+        self.end_lineno = node.end_lineno
+
+
 def visit(tree: ast.Module) -> Mapping[Offset, list[TokenFunc]]:
     """
     Visit the AST and return a list of callbacks to apply to the tokens.
-    This is a placeholder function; actual implementation would depend on
-    the specific migration logic.
     """
     ret: defaultdict[Offset, list[TokenFunc]] = defaultdict(list)
     freezegun_import_seen = False
     freeze_time_import_seen = False
+    freezer_functions: list[FreezerFunction] = []
+    marker_class_methods: set[ast.FunctionDef | ast.AsyncFunctionDef] = set()
+    traveller_vars: list[TravellerVar] = []
     for node in ast.walk(tree):
         match node:
             case ast.Import() if (
@@ -168,36 +202,133 @@ def visit(tree: ast.Module) -> Mapping[Offset, list[TokenFunc]]:
                     )
                 )
             case ast.FunctionDef() | ast.AsyncFunctionDef():
+                marker_seen = node in marker_class_methods
                 for decorator in node.decorator_list:
-                    maybe_migrate_call(
-                        ret,
-                        decorator,
-                        freezegun_import_seen=freezegun_import_seen,
-                        freeze_time_import_seen=freeze_time_import_seen,
+                    if maybe_migrate_marker(ret, decorator):
+                        marker_seen = True
+                    else:
+                        maybe_migrate_call(
+                            ret,
+                            decorator,
+                            freezegun_import_seen=freezegun_import_seen,
+                            freeze_time_import_seen=freeze_time_import_seen,
+                            freezer_functions=freezer_functions,
+                        )
+
+                freezer_args = [
+                    arg
+                    for arg in (*node.args.args, *node.args.kwonlyargs)
+                    if arg.arg == "freezer"
+                ]
+                if freezer_args:
+                    for arg in freezer_args:
+                        ret[ast_start_offset(arg)].append(replace_freezer)
+                    freezer_functions.append(
+                        FreezerFunction(node, marker_seen=marker_seen)
                     )
 
-            case ast.ClassDef() if node.decorator_list and looks_like_unittest_class(
-                node
-            ):
+            case ast.ClassDef() if node.decorator_list:
+                unittest_class = looks_like_unittest_class(node)
                 for decorator in node.decorator_list:
-                    maybe_migrate_call(
-                        ret,
-                        decorator,
-                        freezegun_import_seen=freezegun_import_seen,
-                        freeze_time_import_seen=freeze_time_import_seen,
-                    )
+                    if maybe_migrate_marker(ret, decorator):
+                        marker_class_methods.update(
+                            stmt
+                            for stmt in node.body
+                            if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef))
+                        )
+                    elif unittest_class:
+                        maybe_migrate_call(
+                            ret,
+                            decorator,
+                            freezegun_import_seen=freezegun_import_seen,
+                            freeze_time_import_seen=freeze_time_import_seen,
+                            freezer_functions=freezer_functions,
+                        )
 
             case ast.With():
                 for item in node.items:
-                    if item.optional_vars is None:
-                        maybe_migrate_call(
-                            ret,
-                            item.context_expr,
-                            freezegun_import_seen=freezegun_import_seen,
-                            freeze_time_import_seen=freeze_time_import_seen,
-                        )
+                    match item.optional_vars:
+                        case None:
+                            maybe_migrate_call(
+                                ret,
+                                item.context_expr,
+                                freezegun_import_seen=freezegun_import_seen,
+                                freeze_time_import_seen=freeze_time_import_seen,
+                                freezer_functions=freezer_functions,
+                            )
+                        case ast.Name(id=name) as binding:
+                            if traveller_var_uses_compatible(
+                                node, binding
+                            ) and maybe_migrate_call(
+                                ret,
+                                item.context_expr,
+                                freezegun_import_seen=freezegun_import_seen,
+                                freeze_time_import_seen=freeze_time_import_seen,
+                                freezer_functions=freezer_functions,
+                            ):
+                                traveller_vars.append(TravellerVar(name, node))
+
+            case ast.Expr(
+                value=ast.Call(
+                    func=ast.Attribute(
+                        value=ast.Name(id=receiver) as receiver_node,
+                        attr="tick",
+                    )
+                ) as call_node
+            ) if migratable_tick_call(call_node):
+                # tick() is only migrated as a statement, since shift() does
+                # not return the new time.
+                if receiver == "freezer" and find_freezer_function(
+                    freezer_functions, call_node
+                ):
+                    ret[ast_start_offset(receiver_node)].append(replace_freezer)
+                    ret[ast_start_offset(receiver_node)].append(
+                        partial(replace_tick_with_shift, node=call_node)
+                    )
+                elif any(
+                    traveller_var.name == receiver
+                    and (
+                        traveller_var.lineno
+                        <= call_node.lineno
+                        <= traveller_var.end_lineno
+                    )
+                    for traveller_var in traveller_vars
+                ):
+                    ret[ast_start_offset(receiver_node)].append(
+                        partial(replace_tick_with_shift, node=call_node)
+                    )
+
+            case ast.Call(
+                func=ast.Attribute(
+                    value=ast.Name(id="freezer") as receiver_node,
+                    attr="move_to",
+                )
+            ) if (
+                len(node.args) == 1
+                and not node.keywords
+                and (freezer_function := find_freezer_function(freezer_functions, node))
+                is not None
+            ):
+                ret[ast_start_offset(receiver_node)].append(replace_freezer)
+                if not freezer_function.marker_seen:
+                    ret[ast_start_offset(node)].append(
+                        partial(add_tick_false, node=node)
+                    )
 
     return ret
+
+
+def find_freezer_function(
+    freezer_functions: list[FreezerFunction], node: ast.expr
+) -> FreezerFunction | None:
+    """
+    Find the innermost function with a freezer fixture argument containing the
+    given node, if any.
+    """
+    for function in reversed(freezer_functions):
+        if function.lineno <= node.lineno <= function.end_lineno:
+            return function
+    return None
 
 
 def maybe_migrate_call(
@@ -206,13 +337,14 @@ def maybe_migrate_call(
     *,
     freezegun_import_seen: bool,
     freeze_time_import_seen: bool,
-) -> None:
+    freezer_functions: list[FreezerFunction],
+) -> bool:
     """
     Add the callbacks to rewrite the given expression, if it is a migratable
-    call to freezegun’s freeze_time().
+    call to freezegun’s freeze_time(), returning whether that was the case.
     """
     if not isinstance(node, ast.Call) or not migratable_call(node):
-        return
+        return False
 
     func = node.func
     if not (
@@ -229,17 +361,96 @@ def maybe_migrate_call(
             and func.id == "freeze_time"
         )
     ):
-        return
+        return False
+
+    if find_freezer_function(freezer_functions, node) is not None:
+        # Inside a function whose freezer argument is renamed to
+        # time_machine, shadowing the module, so a rewritten call would not
+        # resolve to it.
+        return False
 
     ret[ast_start_offset(func)].append(partial(switch_to_travel, node=func))
     if not any(kw.arg == "tick" for kw in node.keywords):
         ret[ast_start_offset(node)].append(partial(add_tick_false, node=node))
+    return True
+
+
+def traveller_var_uses_compatible(node: ast.With, binding: ast.Name) -> bool:
+    """
+    Check that a variable bound with ``as`` to a freeze_time() context manager
+    is only used in ways that work the same on time-machine’s Traveller:
+    move_to() calls, and tick() calls as statements, since shift() does not
+    return the new time.
+    """
+    name = binding.id
+    allowed = {binding}
+    for subnode in ast.walk(node):
+        match subnode:
+            case ast.Expr(
+                value=ast.Call(
+                    func=ast.Attribute(
+                        value=ast.Name(id=receiver) as receiver_node,
+                        attr="tick",
+                    )
+                )
+            ) if receiver == name:
+                allowed.add(receiver_node)
+            case ast.Call(
+                func=ast.Attribute(
+                    value=ast.Name(id=receiver) as receiver_node,
+                    attr="move_to",
+                )
+            ) if receiver == name:
+                allowed.add(receiver_node)
+    return all(
+        subnode in allowed
+        for subnode in ast.walk(node)
+        if isinstance(subnode, ast.Name) and subnode.id == name
+    )
+
+
+def maybe_migrate_marker(
+    ret: MutableMapping[Offset, list[TokenFunc]],
+    node: ast.expr,
+) -> bool:
+    """
+    Add the callbacks to rewrite the given decorator, if it is a migratable
+    use of pytest-freezegun / pytest-freezer’s pytest.mark.freeze_time()
+    marker, returning whether that was the case.
+    """
+    if not (
+        isinstance(node, ast.Call)
+        and migratable_call(node)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "freeze_time"
+        and isinstance(node.func.value, ast.Attribute)
+        and node.func.value.attr == "mark"
+        and isinstance(node.func.value.value, ast.Name)
+        and node.func.value.value.id == "pytest"
+    ):
+        return False
+
+    ret[ast_start_offset(node.func)].append(partial(switch_to_marker, node=node.func))
+    if not any(kw.arg == "tick" for kw in node.keywords):
+        ret[ast_start_offset(node)].append(partial(add_tick_false, node=node))
+    return True
 
 
 def migratable_call(node: ast.Call) -> bool:
     return len(node.args) == 1 and (
         len(node.keywords) == 0
         or (len(node.keywords) == 1 and node.keywords[0].arg == "tick")
+    )
+
+
+def migratable_tick_call(node: ast.Call) -> bool:
+    """
+    freezegun’s tick() takes a single optional argument, delta.
+    """
+    if node.args:
+        return len(node.args) == 1 and not node.keywords
+    return not node.keywords or (
+        len(node.keywords) == 1 and node.keywords[0].arg == "delta"
     )
 
 
@@ -327,7 +538,9 @@ UNITTEST_ASSERT_NAMES = frozenset(
 )
 
 
-def ast_start_offset(node: ast.alias | ast.expr | ast.keyword | ast.stmt) -> Offset:
+def ast_start_offset(
+    node: ast.alias | ast.arg | ast.expr | ast.keyword | ast.stmt,
+) -> Offset:
     return Offset(node.lineno, node.col_offset)
 
 
@@ -361,9 +574,14 @@ def replace_import_from(
 
 def line_indent(tokens: list[Token], i: int) -> str:
     """
-    Return the whitespace indenting the line that the given token starts.
+    Return the whitespace indenting the line that the given token starts, or
+    "" if the token does not start a line, like after `if ...:` or `;`.
     """
-    if i > 0 and tokens[i - 1].name in (INDENT, UNIMPORTANT_WS):
+    if (
+        i > 0
+        and tokens[i - 1].name in (INDENT, UNIMPORTANT_WS)
+        and tokens[i - 2].name in ("NEWLINE", "NL", DEDENT)
+    ):
         # no types for tokenize-rt
         return tokens[i - 1].src  # type: ignore [no-any-return]
     return ""
@@ -376,12 +594,43 @@ def switch_to_travel(
     tokens[i : j + 1] = [Token(name=CODE, src="time_machine.travel")]
 
 
+def switch_to_marker(tokens: list[Token], i: int, node: ast.Attribute) -> None:
+    j = find_last_token(tokens, i, node=node)
+    tokens[i : j + 1] = [Token(name=CODE, src="pytest.mark.time_machine")]
+
+
+def replace_freezer(tokens: list[Token], i: int) -> None:
+    tokens[i] = Token(name="NAME", src="time_machine")
+
+
+def replace_tick_with_shift(tokens: list[Token], i: int, node: ast.Call) -> None:
+    """
+    Replace a tick() method call with shift(), making freezegun’s default
+    delta of one second explicit if no argument was passed.
+    """
+    i += 1  # skip the receiver name
+    while not (tokens[i].name == "NAME" and tokens[i].src == "tick"):
+        i += 1
+    tokens[i] = Token(name="NAME", src="shift")
+    if not node.args and not node.keywords:
+        while tokens[i].src != "(":
+            i += 1
+        tokens.insert(i + 1, Token(name=CODE, src="1"))
+
+
 def add_tick_false(tokens: list[Token], i: int, node: ast.Call) -> None:
     """
     Add `tick=False` to the function call, unless `tick` is already set.
     """
     j = find_last_token(tokens, i, node=node)
-    tokens.insert(j, Token(name=CODE, src=", tick=False"))
+    k = j - 1
+    while tokens[k].name in NON_CODING_TOKENS:
+        k -= 1
+    if tokens[k].src == ",":
+        # trailing comma: insert after it
+        tokens.insert(k + 1, Token(name=CODE, src=" tick=False"))
+    else:
+        tokens.insert(j, Token(name=CODE, src=", tick=False"))
 
 
 # Token functions

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -240,6 +240,29 @@ class TestMigrateContents:
             """,
         )
 
+    def test_import_from_freezegun_multiple_compound_statement(self):
+        check_transformed(
+            "if True: from freezegun import freeze_time, FakeDate\n",
+            "if True: import time_machine\nfrom freezegun import FakeDate\n",
+        )
+
+    def test_import_from_freezegun_multiple_indented_after_dedent(self):
+        check_transformed(
+            """\
+            def f():
+                if True:
+                    pass
+                from freezegun import freeze_time, FakeDate
+            """,
+            """\
+            def f():
+                if True:
+                    pass
+                import time_machine
+                from freezegun import FakeDate
+            """,
+        )
+
     def test_import_from_freezegun_multiple_used(self):
         check_transformed(
             """\
@@ -420,6 +443,46 @@ class TestMigrateContents:
             import time_machine
 
             @time_machine.travel("2023-01-01", tick=False)
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_function_decorator_name_trailing_comma(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            @freeze_time("2023-01-01",)
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel("2023-01-01", tick=False)
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_function_decorator_name_multiline(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            @freeze_time(
+                "2023-01-01",
+            )
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel(
+                "2023-01-01", tick=False
+            )
             def test_function():
                 pass
             """,
@@ -806,7 +869,7 @@ class TestMigrateContents:
             """
             import time_machine
 
-            with freezegun.freeze_time("2023-01-01") as ft:
+            with time_machine.travel("2023-01-01", tick=False) as ft:
                 pass
             """,
         )
@@ -880,7 +943,7 @@ class TestMigrateContents:
             """
             import time_machine
 
-            with freeze_time("2023-01-01") as ft:
+            with time_machine.travel("2023-01-01", tick=False) as ft:
                 pass
             """,
         )
@@ -898,5 +961,577 @@ class TestMigrateContents:
 
             with time_machine.travel("2023-01-01", tick=False):
                 pass
+            """,
+        )
+
+    def test_with_as_move_to(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            with freeze_time("2023-01-01") as ft:
+                ft.move_to("2023-06-01")
+            """,
+            """
+            import time_machine
+
+            with time_machine.travel("2023-01-01", tick=False) as ft:
+                ft.move_to("2023-06-01")
+            """,
+        )
+
+    def test_with_as_attribute_target(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            with freeze_time("2023-01-01") as obj.ft:
+                pass
+            """,
+            """
+            import time_machine
+
+            with freeze_time("2023-01-01") as obj.ft:
+                pass
+            """,
+        )
+
+    def test_with_as_tick(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            with freeze_time("2023-01-01") as ft:
+                ft.tick()
+            """,
+            """
+            import time_machine
+
+            with time_machine.travel("2023-01-01", tick=False) as ft:
+                ft.shift(1)
+            """,
+        )
+
+    def test_with_as_tick_arguments(self):
+        check_transformed(
+            """
+            from datetime import timedelta
+            from freezegun import freeze_time
+
+            with freeze_time("2023-01-01") as ft:
+                ft.tick(10.0)
+                ft.tick(timedelta(seconds=100))
+                ft.tick(delta=timedelta(seconds=100))
+            """,
+            """
+            from datetime import timedelta
+            import time_machine
+
+            with time_machine.travel("2023-01-01", tick=False) as ft:
+                ft.shift(10.0)
+                ft.shift(timedelta(seconds=100))
+                ft.shift(delta=timedelta(seconds=100))
+            """,
+        )
+
+    def test_with_as_tick_too_many_arguments(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            with freeze_time("2023-01-01") as ft:
+                ft.tick(1, 2)
+            """,
+            """
+            import time_machine
+
+            with time_machine.travel("2023-01-01", tick=False) as ft:
+                ft.tick(1, 2)
+            """,
+        )
+
+    def test_with_as_tick_other_name(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            with freeze_time("2023-01-01") as ft:
+                other.tick()
+            """,
+            """
+            import time_machine
+
+            with time_machine.travel("2023-01-01", tick=False) as ft:
+                other.tick()
+            """,
+        )
+
+    def test_with_as_tick_outside_block(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            with freeze_time("2023-01-01") as ft:
+                pass
+            ft.tick()
+            """,
+            """
+            import time_machine
+
+            with time_machine.travel("2023-01-01", tick=False) as ft:
+                pass
+            ft.tick()
+            """,
+        )
+
+    def test_with_as_tick_assigned(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            with freeze_time("2023-01-01") as ft:
+                now = ft.tick()
+            """,
+            """
+            import time_machine
+
+            with freeze_time("2023-01-01") as ft:
+                now = ft.tick()
+            """,
+        )
+
+    def test_with_as_incompatible_attribute(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            with freeze_time("2023-01-01") as ft:
+                assert ft.time_to_freeze.year == 2023
+            """,
+            """
+            import time_machine
+
+            with freeze_time("2023-01-01") as ft:
+                assert ft.time_to_freeze.year == 2023
+            """,
+        )
+
+    def test_with_as_incompatible_reference(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            with freeze_time("2023-01-01") as ft:
+                helper(ft)
+            """,
+            """
+            import time_machine
+
+            with freeze_time("2023-01-01") as ft:
+                helper(ft)
+            """,
+        )
+
+    def test_with_as_unmigratable_call(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            with freeze_time("2023-01-01", auto_tick_seconds=1) as ft:
+                ft.tick()
+            """,
+            """
+            import time_machine
+
+            with freeze_time("2023-01-01", auto_tick_seconds=1) as ft:
+                ft.tick()
+            """,
+        )
+
+    def test_marker(self):
+        check_transformed(
+            """
+            import pytest
+
+            @pytest.mark.freeze_time("2023-01-01")
+            def test_function():
+                pass
+            """,
+            """
+            import pytest
+
+            @pytest.mark.time_machine("2023-01-01", tick=False)
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_marker_async_function(self):
+        check_transformed(
+            """
+            import pytest
+
+            @pytest.mark.freeze_time("2023-01-01")
+            async def test_function():
+                pass
+            """,
+            """
+            import pytest
+
+            @pytest.mark.time_machine("2023-01-01", tick=False)
+            async def test_function():
+                pass
+            """,
+        )
+
+    def test_marker_tick(self):
+        check_transformed(
+            """
+            import pytest
+
+            @pytest.mark.freeze_time("2023-01-01", tick=True)
+            def test_function():
+                pass
+            """,
+            """
+            import pytest
+
+            @pytest.mark.time_machine("2023-01-01", tick=True)
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_marker_not_called(self):
+        check_noop(
+            """
+            import pytest
+
+            @pytest.mark.freeze_time
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_marker_unmigratable_call(self):
+        check_noop(
+            """
+            import pytest
+
+            @pytest.mark.freeze_time("2023-01-01", auto_tick_seconds=1)
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_marker_unrelated(self):
+        check_noop(
+            """
+            import pytest
+
+            @pytest.mark.slow_time("2023-01-01")
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_marker_class(self):
+        check_transformed(
+            """
+            import pytest
+
+            @pytest.mark.freeze_time("2023-01-01")
+            class TestSomething:
+                def test_function(self):
+                    pass
+            """,
+            """
+            import pytest
+
+            @pytest.mark.time_machine("2023-01-01", tick=False)
+            class TestSomething:
+                def test_function(self):
+                    pass
+            """,
+        )
+
+    def test_freezer_fixture(self):
+        check_transformed(
+            """
+            def test_function(freezer):
+                freezer.move_to("2023-01-01")
+            """,
+            """
+            def test_function(time_machine):
+                time_machine.move_to("2023-01-01", tick=False)
+            """,
+        )
+
+    def test_freezer_fixture_async_function(self):
+        check_transformed(
+            """
+            async def test_function(freezer):
+                freezer.move_to("2023-01-01")
+            """,
+            """
+            async def test_function(time_machine):
+                time_machine.move_to("2023-01-01", tick=False)
+            """,
+        )
+
+    def test_freezer_fixture_keyword_only(self):
+        check_transformed(
+            """
+            def test_function(*, freezer):
+                freezer.move_to("2023-01-01")
+            """,
+            """
+            def test_function(*, time_machine):
+                time_machine.move_to("2023-01-01", tick=False)
+            """,
+        )
+
+    def test_freezer_fixture_move_to_extra_arguments(self):
+        check_transformed(
+            """
+            def test_function(freezer):
+                freezer.move_to("2023-01-01", "2024-01-01")
+            """,
+            """
+            def test_function(time_machine):
+                freezer.move_to("2023-01-01", "2024-01-01")
+            """,
+        )
+
+    def test_freezer_fixture_parenthesized_receiver(self):
+        check_transformed(
+            """
+            def test_function(freezer):
+                (freezer).move_to("2023-01-01")
+                (freezer).tick()
+            """,
+            """
+            def test_function(time_machine):
+                (time_machine).move_to("2023-01-01", tick=False)
+                (time_machine).shift(1)
+            """,
+        )
+
+    def test_with_as_tick_parenthesized_receiver(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            with freeze_time("2023-01-01") as tick:
+                (tick).tick()
+            """,
+            """
+            import time_machine
+
+            with time_machine.travel("2023-01-01", tick=False) as tick:
+                (tick).shift(1)
+            """,
+        )
+
+    def test_freezer_fixture_other_method(self):
+        check_transformed(
+            """
+            def test_function(freezer):
+                freezer.move_to("2023-01-01")
+                freezer.start()
+            """,
+            """
+            def test_function(time_machine):
+                time_machine.move_to("2023-01-01", tick=False)
+                freezer.start()
+            """,
+        )
+
+    def test_freezer_fixture_tick(self):
+        check_transformed(
+            """
+            from datetime import timedelta
+
+            def test_function(freezer):
+                freezer.tick()
+                freezer.tick(10.0)
+                freezer.tick(100)
+                freezer.tick(timedelta(seconds=100))
+                freezer.tick(delta=timedelta(seconds=100))
+            """,
+            """
+            from datetime import timedelta
+
+            def test_function(time_machine):
+                time_machine.shift(1)
+                time_machine.shift(10.0)
+                time_machine.shift(100)
+                time_machine.shift(timedelta(seconds=100))
+                time_machine.shift(delta=timedelta(seconds=100))
+            """,
+        )
+
+    def test_freezer_fixture_tick_assigned(self):
+        check_transformed(
+            """
+            def test_function(freezer):
+                now = freezer.tick()
+            """,
+            """
+            def test_function(time_machine):
+                now = freezer.tick()
+            """,
+        )
+
+    def test_freezer_fixture_move_to_assigned(self):
+        check_transformed(
+            """
+            def test_function(freezer):
+                result = freezer.move_to("2023-01-01")
+            """,
+            """
+            def test_function(time_machine):
+                result = time_machine.move_to("2023-01-01", tick=False)
+            """,
+        )
+
+    def test_freezer_fixture_shadowed_freeze_time(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            def test_function(freezer):
+                freezer.move_to("2023-01-01")
+                with freeze_time("2024-01-01"):
+                    pass
+            """,
+            """
+            import time_machine
+
+            def test_function(time_machine):
+                time_machine.move_to("2023-01-01", tick=False)
+                with freeze_time("2024-01-01"):
+                    pass
+            """,
+        )
+
+    def test_freezer_fixture_no_argument_noop(self):
+        check_noop(
+            """
+            def test_function():
+                freezer.move_to("2023-01-01")
+            """,
+        )
+
+    def test_freezer_fixture_module_level_noop(self):
+        check_noop(
+            """
+            freezer.move_to("2023-01-01")
+            """,
+        )
+
+    def test_freezer_fixture_with_marker(self):
+        check_transformed(
+            """
+            import pytest
+
+            @pytest.mark.freeze_time("2000-01-01")
+            def test_function(freezer):
+                freezer.move_to("2023-01-01")
+            """,
+            """
+            import pytest
+
+            @pytest.mark.time_machine("2000-01-01", tick=False)
+            def test_function(time_machine):
+                time_machine.move_to("2023-01-01")
+            """,
+        )
+
+    def test_freezer_fixture_with_marker_tick(self):
+        check_transformed(
+            """
+            import pytest
+
+            @pytest.mark.freeze_time("2000-01-01", tick=True)
+            def test_function(freezer):
+                freezer.move_to("2023-01-01")
+            """,
+            """
+            import pytest
+
+            @pytest.mark.time_machine("2000-01-01", tick=True)
+            def test_function(time_machine):
+                time_machine.move_to("2023-01-01")
+            """,
+        )
+
+    def test_freezer_fixture_with_class_marker(self):
+        check_transformed(
+            """
+            import pytest
+
+            @pytest.mark.freeze_time("2000-01-01")
+            class TestSomething:
+                def test_function(self, freezer):
+                    freezer.move_to("2023-01-01")
+            """,
+            """
+            import pytest
+
+            @pytest.mark.time_machine("2000-01-01", tick=False)
+            class TestSomething:
+                def test_function(self, time_machine):
+                    time_machine.move_to("2023-01-01")
+            """,
+        )
+
+    def test_freezer_fixture_with_decorator(self):
+        check_transformed(
+            """
+            import freezegun
+
+            @freezegun.freeze_time("2000-01-01")
+            def test_function(freezer):
+                freezer.move_to("2023-01-01")
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel("2000-01-01", tick=False)
+            def test_function(time_machine):
+                time_machine.move_to("2023-01-01", tick=False)
+            """,
+        )
+
+    def test_freezer_fixture_mix(self):
+        check_transformed(
+            """
+            import freezegun
+            import pytest
+
+            def test_function():
+                with freezegun.freeze_time("2000-01-01") as t:
+                    t.move_to("2023-01-01")
+                    t.tick()
+
+            @pytest.mark.freeze_time("2000-01-01")
+            def test_function2(freezer):
+                freezer.move_to("2023-01-01")
+                freezer.tick()
+            """,
+            """
+            import time_machine
+            import pytest
+
+            def test_function():
+                with time_machine.travel("2000-01-01", tick=False) as t:
+                    t.move_to("2023-01-01")
+                    t.shift(1)
+
+            @pytest.mark.time_machine("2000-01-01", tick=False)
+            def test_function2(time_machine):
+                time_machine.move_to("2023-01-01")
+                time_machine.shift(1)
             """,
         )

--- a/tests/test_cli_fuzz.py
+++ b/tests/test_cli_fuzz.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import ast
+import sys
+
+import pytest
+
+if sys.version_info[:2] == (3, 13) and not sys._is_gil_enabled():
+    # Hypothesis has no free-threaded wheels for Python 3.13, and cannot be
+    # built from source there, since PyO3 does not support free-threaded
+    # Python < 3.14.
+    pytest.skip("Hypothesis unavailable", allow_module_level=True)
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from time_machine.cli import migrate_contents
+
+# Fuzz the migration CLI with generated source files combining the constructs
+# that it targets, varying formatting. The generated code only needs to parse,
+# not run, so undefined names are fine.
+
+
+def indent(block: str) -> str:
+    return "\n".join(f"    {line}" for line in block.splitlines())
+
+
+freeze_time_callees = st.sampled_from(
+    [
+        "freeze_time",
+        "freezegun.freeze_time",
+        "(freeze_time)",
+        "fg.freeze_time",
+    ]
+)
+
+freeze_time_arglists = st.sampled_from(
+    [
+        (),
+        ('"2023-01-01"',),
+        ("dest",),
+        ('"2023-01-01"', "tick=True"),
+        ('"2023-01-01"', "tick=False"),
+        ('"2023-01-01"', "auto_tick_seconds=1"),
+    ]
+)
+
+method_arglists = st.sampled_from(
+    [
+        (),
+        ('"2023-01-01"',),
+        ('"2023-01-01"', '"2024-01-01"'),
+        ("1",),
+        ("delta=1",),
+        ("tick=True",),
+    ]
+)
+
+
+@st.composite
+def calls(
+    draw: st.DrawFn, callee: str, arglists: st.SearchStrategy[tuple[str, ...]]
+) -> str:
+    args = list(draw(arglists))
+    style = draw(st.sampled_from(["plain", "spaced", "trailing_comma", "multiline"]))
+    if not args or style == "plain":
+        return f"{callee}({', '.join(args)})"
+    elif style == "spaced":
+        return f"{callee} ( {' , '.join(args)} )"
+    elif style == "trailing_comma":
+        return f"{callee}({', '.join(args)},)"
+    else:
+        comment = "  # comment" if draw(st.booleans()) else ""
+        return f"{callee}(" + "".join(f"\n    {arg},{comment}" for arg in args) + "\n)"
+
+
+@st.composite
+def freeze_time_calls(draw: st.DrawFn) -> str:
+    return draw(calls(draw(freeze_time_callees), freeze_time_arglists))
+
+
+@st.composite
+def decorators(draw: st.DrawFn) -> str:
+    kind = draw(st.sampled_from(["freeze_time", "marker", "not_called", "unrelated"]))
+    if kind == "freeze_time":
+        return "@" + draw(freeze_time_calls())
+    elif kind == "marker":
+        return "@" + draw(calls("pytest.mark.freeze_time", freeze_time_arglists))
+    elif kind == "not_called":
+        return draw(
+            st.sampled_from(
+                ["@freeze_time", "@pytest.mark.freeze_time", "@freezegun.freeze_time"]
+            )
+        )
+    else:
+        return '@mock.patch("example.thing")'
+
+
+@st.composite
+def method_statements(draw: st.DrawFn) -> str:
+    receiver = draw(st.sampled_from(["freezer", "t", "ft", "tick", "other"]))
+    kind = draw(st.sampled_from(["call", "call", "call", "attribute", "reference"]))
+    if kind == "attribute":
+        return f"assert {receiver}.time_to_freeze"
+    elif kind == "reference":
+        return f"helper({receiver})"
+    wrapped = draw(st.sampled_from(["{}", "({})", "( {} )", "({}\n)"])).format(receiver)
+    dot = draw(st.sampled_from([".", " . "]))
+    method = draw(st.sampled_from(["move_to", "tick", "shift", "start"]))
+    statement = draw(calls(f"{wrapped}{dot}{method}", method_arglists))
+    if draw(st.booleans()):
+        statement = f"x = {statement}"
+    if draw(st.booleans()):
+        statement += "; " + draw(calls(f"{receiver}.tick", method_arglists))
+    return statement
+
+
+@st.composite
+def with_statements(draw: st.DrawFn) -> str:
+    items = []
+    for _ in range(draw(st.integers(1, 2))):
+        item = draw(freeze_time_calls())
+        as_name = draw(st.sampled_from([None, "t", "ft", "tick", "freezer"]))
+        if as_name is not None:
+            item += f" as {as_name}"
+        items.append(item)
+    body = draw(st.lists(st.just("pass") | method_statements(), min_size=1, max_size=2))
+    joined = ", ".join(items)
+    if len(items) > 1 and draw(st.booleans()):
+        joined = f"({joined})"
+    return f"with {joined}:\n" + "\n".join(indent(s) for s in body)
+
+
+@st.composite
+def function_defs(draw: st.DrawFn) -> str:
+    lines = draw(st.lists(decorators(), max_size=2))
+    prefix = "async " if draw(st.booleans()) else ""
+    params = draw(
+        st.sampled_from(
+            ["", "freezer", "self, freezer", "*, freezer", "freezer, other", "other"]
+        )
+    )
+    lines.append(f"{prefix}def test_function({params}):")
+    body = draw(
+        st.lists(
+            st.just("pass")
+            | st.just("from freezegun import freeze_time, FakeDate")
+            | method_statements()
+            | with_statements(),
+            min_size=1,
+            max_size=3,
+        )
+    )
+    lines.extend(indent(s) for s in body)
+    return "\n".join(lines)
+
+
+@st.composite
+def class_defs(draw: st.DrawFn) -> str:
+    lines = draw(st.lists(decorators(), max_size=1))
+    bases = draw(st.sampled_from(["", "(unittest.TestCase)", "(TestBase)"]))
+    lines.append(f"class TestSomething{bases}:")
+    body = draw(st.lists(st.just("pass") | function_defs(), min_size=1, max_size=2))
+    lines.extend(indent(s) for s in body)
+    return "\n".join(lines)
+
+
+imports = st.sampled_from(
+    [
+        "import freezegun",
+        "import freezegun as fg",
+        "from freezegun import freeze_time",
+        "from freezegun import freeze_time, FakeDate",
+        "if True: from freezegun import freeze_time, FakeDate",
+        "import pytest",
+    ]
+)
+
+
+@st.composite
+def modules(draw: st.DrawFn) -> str:
+    parts = draw(st.lists(imports, unique=True, max_size=3))
+    parts.extend(
+        draw(
+            st.lists(
+                function_defs()
+                | class_defs()
+                | with_statements()
+                | method_statements(),
+                min_size=1,
+                max_size=3,
+            )
+        )
+    )
+    return "\n\n".join(parts) + "\n"
+
+
+@settings(deadline=None, max_examples=200)
+@given(source=modules())
+def test_migrate_contents_properties(source: str) -> None:
+    ast.parse(source)  # the grammar should only generate valid code
+
+    migrated = migrate_contents(source)  # must not crash
+
+    # the output must still be valid Python
+    ast.parse(migrated)
+
+    # migration must be idempotent
+    assert migrate_contents(migrated) == migrated


### PR DESCRIPTION
The Migration CLI command now handles:

* The `freezer` fixture from pytest-freezegun / pytest-freezer: arguments named `freezer` are renamed to `time_machine`, `freezer.move_to()` gains `tick=False` where the fixture would not inherit tick behaviour from a migrated marker, and `freezer.tick()` becomes `time_machine.shift()` with the default delta of one second made explicit.

* The `pytest.mark.freeze_time` marker, on functions and classes, which becomes `pytest.mark.time_machine` with the same tick handling as `freeze_time()` calls.

* `freeze_time()` context managers that bind the result with `as`, previously skipped, including converting the bound variable's `tick()` method calls to `shift()`.

On the way, fix a couple of bugs (see changelog).