### PR TITLE
Document pytest marker takes args

### DIFF
--- a/docs/pytest_plugin.rst
+++ b/docs/pytest_plugin.rst
@@ -39,6 +39,20 @@ Or for a class:
         def test_two(self):
             assert dt.date.today().isoformat() == "1985-10-26"
 
+The marker takes the same arguments as :class:`~.travel`, including the ``tick`` argument:
+
+.. code-block:: python
+
+    import time
+
+    import pytest
+
+
+    @pytest.mark.time_machine(0, tick=False)
+    def test_delorean_marker_tick():
+        for _ in range(10):
+            assert time.time() == 0.0
+
 ``time_machine`` fixture
 ------------------------
 

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -1826,6 +1826,23 @@ def test_marker_and_fixture(testdir):
     result.assert_outcomes(passed=1)
 
 
+def test_marker_function_arg(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+        import time
+
+        @pytest.mark.time_machine(0, tick=False)
+        def test():
+            for _ in range(10):
+                assert time.time() == 0.0
+    """
+    )
+
+    result = testdir.runpytest("-v", "-s")
+    result.assert_outcomes(passed=1)
+
+
 def test_marker_class(testdir):
     testdir.makepyfile(
         """


### PR DESCRIPTION
This has always been possible, just not documented.