### PR TITLE
Extend Migration CLI to migrate aliased freezegun imports

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Extend the :ref:`Migration CLI <migration-cli>` to migrate aliased imports: ``import freezegun as fg`` and ``from freezegun import freeze_time as ft``, plus calls using such aliases.
+
 3.4.0 (2026-08-10)
 ------------------
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -83,6 +83,9 @@ The changes the tool makes are:
 
 * ``from freezegun import freeze_time`` -> ``import time_machine``
 
+* Aliased imports like ``import freezegun as fg`` or ``from freezegun import freeze_time as ft`` -> ``import time_machine``.
+  The alias is dropped, since calls using it are migrated to use the ``time_machine`` module, per the below.
+
 * ``from freezegun import freeze_time, FakeDate`` -> ``import time_machine`` plus ``from freezegun import FakeDate``, keeping the other imported names.
 
 * In function decorators, class decorators, and context managers: ``freeze_time(...)`` -> ``travel(...)``.

--- a/src/time_machine/cli.py
+++ b/src/time_machine/cli.py
@@ -167,29 +167,33 @@ def visit(tree: ast.Module) -> Mapping[Offset, list[TokenFunc]]:
     Visit the AST and return a list of callbacks to apply to the tokens.
     """
     ret: defaultdict[Offset, list[TokenFunc]] = defaultdict(list)
-    freezegun_import_seen = False
-    freeze_time_import_seen = False
+    freezegun_module_names: set[str] = set()
+    freeze_time_names: set[str] = set()
     freezer_functions: list[FreezerFunction] = []
     marker_class_methods: set[ast.FunctionDef | ast.AsyncFunctionDef] = set()
     traveller_vars: list[TravellerVar] = []
     for node in ast.walk(tree):
         match node:
             case ast.Import() if (
-                len(node.names) == 1
-                and (alias := node.names[0]).name == "freezegun"
-                and alias.asname is None
+                len(node.names) == 1 and (alias := node.names[0]).name == "freezegun"
             ):
-                freezegun_import_seen = True
-                ret[ast_start_offset(node)].append(replace_import)
+                freezegun_module_names.add(alias.asname or "freezegun")
+                if alias.asname is None:
+                    ret[ast_start_offset(node)].append(replace_import)
+                else:
+                    ret[ast_start_offset(node)].append(
+                        partial(replace_aliased_import, node=node)
+                    )
             case ast.ImportFrom() if (
                 node.level == 0
                 and node.module == "freezegun"
-                and any(
-                    alias.name == "freeze_time" and alias.asname is None
-                    for alias in node.names
-                )
+                and any(alias.name == "freeze_time" for alias in node.names)
             ):
-                freeze_time_import_seen = True
+                freeze_time_names.update(
+                    alias.asname or alias.name
+                    for alias in node.names
+                    if alias.name == "freeze_time"
+                )
                 ret[ast_start_offset(node)].append(
                     partial(
                         replace_import_from,
@@ -197,7 +201,7 @@ def visit(tree: ast.Module) -> Mapping[Offset, list[TokenFunc]]:
                         keep=[
                             unparse_alias(alias)
                             for alias in node.names
-                            if alias.name != "freeze_time" or alias.asname is not None
+                            if alias.name != "freeze_time"
                         ],
                     )
                 )
@@ -210,8 +214,8 @@ def visit(tree: ast.Module) -> Mapping[Offset, list[TokenFunc]]:
                         maybe_migrate_call(
                             ret,
                             decorator,
-                            freezegun_import_seen=freezegun_import_seen,
-                            freeze_time_import_seen=freeze_time_import_seen,
+                            freezegun_module_names=freezegun_module_names,
+                            freeze_time_names=freeze_time_names,
                             freezer_functions=freezer_functions,
                         )
 
@@ -240,8 +244,8 @@ def visit(tree: ast.Module) -> Mapping[Offset, list[TokenFunc]]:
                         maybe_migrate_call(
                             ret,
                             decorator,
-                            freezegun_import_seen=freezegun_import_seen,
-                            freeze_time_import_seen=freeze_time_import_seen,
+                            freezegun_module_names=freezegun_module_names,
+                            freeze_time_names=freeze_time_names,
                             freezer_functions=freezer_functions,
                         )
 
@@ -252,8 +256,8 @@ def visit(tree: ast.Module) -> Mapping[Offset, list[TokenFunc]]:
                             maybe_migrate_call(
                                 ret,
                                 item.context_expr,
-                                freezegun_import_seen=freezegun_import_seen,
-                                freeze_time_import_seen=freeze_time_import_seen,
+                                freezegun_module_names=freezegun_module_names,
+                                freeze_time_names=freeze_time_names,
                                 freezer_functions=freezer_functions,
                             )
                         case ast.Name(id=name) as binding:
@@ -262,8 +266,8 @@ def visit(tree: ast.Module) -> Mapping[Offset, list[TokenFunc]]:
                             ) and maybe_migrate_call(
                                 ret,
                                 item.context_expr,
-                                freezegun_import_seen=freezegun_import_seen,
-                                freeze_time_import_seen=freeze_time_import_seen,
+                                freezegun_module_names=freezegun_module_names,
+                                freeze_time_names=freeze_time_names,
                                 freezer_functions=freezer_functions,
                             ):
                                 traveller_vars.append(TravellerVar(name, node))
@@ -335,8 +339,8 @@ def maybe_migrate_call(
     ret: MutableMapping[Offset, list[TokenFunc]],
     node: ast.expr,
     *,
-    freezegun_import_seen: bool,
-    freeze_time_import_seen: bool,
+    freezegun_module_names: set[str],
+    freeze_time_names: set[str],
     freezer_functions: list[FreezerFunction],
 ) -> bool:
     """
@@ -349,17 +353,12 @@ def maybe_migrate_call(
     func = node.func
     if not (
         (
-            freezegun_import_seen
-            and isinstance(func, ast.Attribute)
+            isinstance(func, ast.Attribute)
             and func.attr == "freeze_time"
             and isinstance(func.value, ast.Name)
-            and func.value.id == "freezegun"
+            and func.value.id in freezegun_module_names
         )
-        or (
-            freeze_time_import_seen
-            and isinstance(func, ast.Name)
-            and func.id == "freeze_time"
-        )
+        or (isinstance(func, ast.Name) and func.id in freeze_time_names)
     ):
         return False
 
@@ -550,6 +549,16 @@ def replace_import(tokens: list[Token], i: int) -> None:
             break
         i += 1
     tokens[i] = Token(name="NAME", src="time_machine")
+
+
+def replace_aliased_import(tokens: list[Token], i: int, node: ast.Import) -> None:
+    """
+    Replace an ``import freezegun as <name>`` statement with
+    ``import time_machine``, dropping the alias since calls of
+    ``<name>.freeze_time()`` are rewritten to ``time_machine.travel()``.
+    """
+    j = find_last_token(tokens, i, node=node)
+    tokens[i : j + 1] = [Token(name=CODE, src="import time_machine")]
 
 
 def unparse_alias(alias: ast.alias) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -156,8 +156,27 @@ class TestMigrateContents:
         )
 
     def test_aliased(self):
-        check_noop(
+        check_transformed(
             "import freezegun as fg",
+            "import time_machine",
+        )
+
+    def test_aliased_used(self):
+        check_transformed(
+            """
+            import freezegun as fg
+
+            @fg.freeze_time("2023-01-01")
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel("2023-01-01", tick=False)
+            def test_function():
+                pass
+            """,
         )
 
     def test_import_freezegun(self):
@@ -177,8 +196,43 @@ class TestMigrateContents:
         )
 
     def test_import_from_freezegun_aliased(self):
-        check_noop(
+        check_transformed(
             "from freezegun import freeze_time as ft",
+            "import time_machine",
+        )
+
+    def test_import_from_freezegun_aliased_used(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time as ft
+
+            @ft("2023-01-01")
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel("2023-01-01", tick=False)
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_import_from_freezegun_aliased_used_with(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time as ft
+
+            with ft("2023-01-01") as t:
+                t.tick()
+            """,
+            """
+            import time_machine
+
+            with time_machine.travel("2023-01-01", tick=False) as t:
+                t.shift(1)
+            """,
         )
 
     def test_import_from_freezegun_multiple(self):
@@ -194,8 +248,9 @@ class TestMigrateContents:
         )
 
     def test_import_from_freezegun_multiple_only_aliased_freeze_time(self):
-        check_noop(
+        check_transformed(
             "from freezegun import freeze_time as ft, FakeDate",
+            "import time_machine\nfrom freezegun import FakeDate",
         )
 
     def test_import_from_freezegun_multiple_parenthesized(self):


### PR DESCRIPTION
Handle `import freezegun as fg` and `from freezegun import freeze_time as ft`, replacing them with `import time_machine` and migrating calls that use the aliases.
