### PR TITLE
Extend Migration CLI to migrate markers in pytestmark assignments

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,8 @@ Unreleased
 
 * Extend the :ref:`Migration CLI <migration-cli>` to migrate aliased imports: ``import freezegun as fg`` and ``from freezegun import freeze_time as ft``, plus calls using such aliases.
 
+* Extend the :ref:`Migration CLI <migration-cli>` to migrate the ``pytest.mark.freeze_time`` marker in module-level and class-level ``pytestmark`` assignments.
+
 3.4.0 (2026-08-10)
 ------------------
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -99,6 +99,8 @@ The changes the tool makes are:
 * The ``pytest.mark.freeze_time`` marker from `pytest-freezegun <https://pypi.org/project/pytest-freezegun/>`__ or `pytest-freezer <https://pypi.org/project/pytest-freezer/>`__: ``@pytest.mark.freeze_time(...)`` -> ``@pytest.mark.time_machine(...)``, the marker from time-machine’s :doc:`pytest plugin <pytest_plugin>`.
   This migration uses the same argument handling as for ``freeze_time()`` calls.
 
+  As well as in decorators, the marker is migrated in module-level and class-level ``pytestmark`` assignments, whether assigned alone or within a list or tuple of markers.
+
 * The ``freezer`` fixture from pytest-freezegun or pytest-freezer -> the ``time_machine`` fixture from time-machine’s pytest plugin.
   In functions with an argument named ``freezer``, the argument is renamed to ``time_machine`` and calls of the fixture’s methods are migrated:
 

--- a/src/time_machine/cli.py
+++ b/src/time_machine/cli.py
@@ -171,9 +171,14 @@ def visit(tree: ast.Module) -> Mapping[Offset, list[TokenFunc]]:
     freeze_time_names: set[str] = set()
     freezer_functions: list[FreezerFunction] = []
     marker_class_methods: set[ast.FunctionDef | ast.AsyncFunctionDef] = set()
+    module_marker_seen = False
     traveller_vars: list[TravellerVar] = []
     for node in ast.walk(tree):
         match node:
+            case ast.Module():
+                for stmt in node.body:
+                    if maybe_migrate_pytestmark(ret, stmt):
+                        module_marker_seen = True
             case ast.Import() if (
                 len(node.names) == 1 and (alias := node.names[0]).name == "freezegun"
             ):
@@ -206,7 +211,7 @@ def visit(tree: ast.Module) -> Mapping[Offset, list[TokenFunc]]:
                     )
                 )
             case ast.FunctionDef() | ast.AsyncFunctionDef():
-                marker_seen = node in marker_class_methods
+                marker_seen = module_marker_seen or node in marker_class_methods
                 for decorator in node.decorator_list:
                     if maybe_migrate_marker(ret, decorator):
                         marker_seen = True
@@ -231,23 +236,30 @@ def visit(tree: ast.Module) -> Mapping[Offset, list[TokenFunc]]:
                         FreezerFunction(node, marker_seen=marker_seen)
                     )
 
-            case ast.ClassDef() if node.decorator_list:
-                unittest_class = looks_like_unittest_class(node)
-                for decorator in node.decorator_list:
-                    if maybe_migrate_marker(ret, decorator):
-                        marker_class_methods.update(
-                            stmt
-                            for stmt in node.body
-                            if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef))
-                        )
-                    elif unittest_class:
-                        maybe_migrate_call(
-                            ret,
-                            decorator,
-                            freezegun_module_names=freezegun_module_names,
-                            freeze_time_names=freeze_time_names,
-                            freezer_functions=freezer_functions,
-                        )
+            case ast.ClassDef():
+                class_marker_seen = False
+                if node.decorator_list:
+                    unittest_class = looks_like_unittest_class(node)
+                    for decorator in node.decorator_list:
+                        if maybe_migrate_marker(ret, decorator):
+                            class_marker_seen = True
+                        elif unittest_class:
+                            maybe_migrate_call(
+                                ret,
+                                decorator,
+                                freezegun_module_names=freezegun_module_names,
+                                freeze_time_names=freeze_time_names,
+                                freezer_functions=freezer_functions,
+                            )
+                for stmt in node.body:
+                    if maybe_migrate_pytestmark(ret, stmt):
+                        class_marker_seen = True
+                if class_marker_seen:
+                    marker_class_methods.update(
+                        stmt
+                        for stmt in node.body
+                        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef))
+                    )
 
             case ast.With():
                 for item in node.items:
@@ -406,6 +418,37 @@ def traveller_var_uses_compatible(node: ast.With, binding: ast.Name) -> bool:
         for subnode in ast.walk(node)
         if isinstance(subnode, ast.Name) and subnode.id == name
     )
+
+
+def maybe_migrate_pytestmark(
+    ret: MutableMapping[Offset, list[TokenFunc]],
+    node: ast.stmt,
+) -> bool:
+    """
+    Add the callbacks to rewrite any migratable pytest.mark.freeze_time()
+    markers in the given statement, if it is a ``pytestmark`` assignment,
+    returning whether any were migrated.
+    """
+    elements: list[ast.expr]
+    match node:
+        case ast.Assign(
+            targets=[ast.Name(id="pytestmark")],
+            value=ast.Call() as single,
+        ):
+            elements = [single]
+        case ast.Assign(
+            targets=[ast.Name(id="pytestmark")],
+            value=ast.List(elts=elements) | ast.Tuple(elts=elements),
+        ):
+            pass
+        case _:
+            return False
+
+    migrated = False
+    for element in elements:
+        if maybe_migrate_marker(ret, element):
+            migrated = True
+    return migrated
 
 
 def maybe_migrate_marker(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1310,6 +1310,171 @@ class TestMigrateContents:
             """,
         )
 
+    def test_pytestmark_module(self):
+        check_transformed(
+            """
+            import pytest
+
+            pytestmark = pytest.mark.freeze_time("2023-01-01")
+            """,
+            """
+            import pytest
+
+            pytestmark = pytest.mark.time_machine("2023-01-01", tick=False)
+            """,
+        )
+
+    def test_pytestmark_module_tick(self):
+        check_transformed(
+            """
+            import pytest
+
+            pytestmark = pytest.mark.freeze_time("2023-01-01", tick=True)
+            """,
+            """
+            import pytest
+
+            pytestmark = pytest.mark.time_machine("2023-01-01", tick=True)
+            """,
+        )
+
+    def test_pytestmark_module_list(self):
+        check_transformed(
+            """
+            import pytest
+
+            pytestmark = [
+                pytest.mark.freeze_time("2023-01-01"),
+                pytest.mark.django_db,
+            ]
+            """,
+            """
+            import pytest
+
+            pytestmark = [
+                pytest.mark.time_machine("2023-01-01", tick=False),
+                pytest.mark.django_db,
+            ]
+            """,
+        )
+
+    def test_pytestmark_module_tuple(self):
+        check_transformed(
+            """
+            import pytest
+
+            pytestmark = (pytest.mark.freeze_time("2023-01-01"),)
+            """,
+            """
+            import pytest
+
+            pytestmark = (pytest.mark.time_machine("2023-01-01", tick=False),)
+            """,
+        )
+
+    def test_pytestmark_module_unrelated_marker(self):
+        check_noop(
+            """
+            import pytest
+
+            pytestmark = pytest.mark.django_db()
+            """,
+        )
+
+    def test_pytestmark_module_not_called(self):
+        check_noop(
+            """
+            import pytest
+
+            pytestmark = pytest.mark.freeze_time
+            """,
+        )
+
+    def test_pytestmark_module_other_value(self):
+        check_noop(
+            """
+            pytestmark = marks
+            """,
+        )
+
+    def test_pytestmark_class(self):
+        check_transformed(
+            """
+            import pytest
+
+            class TestSomething:
+                pytestmark = pytest.mark.freeze_time("2023-01-01")
+            """,
+            """
+            import pytest
+
+            class TestSomething:
+                pytestmark = pytest.mark.time_machine("2023-01-01", tick=False)
+            """,
+        )
+
+    def test_pytestmark_module_freezer_fixture(self):
+        check_transformed(
+            """
+            import pytest
+
+            pytestmark = pytest.mark.freeze_time("2000-01-01")
+
+            def test_function(freezer):
+                freezer.move_to("2023-01-01")
+            """,
+            """
+            import pytest
+
+            pytestmark = pytest.mark.time_machine("2000-01-01", tick=False)
+
+            def test_function(time_machine):
+                time_machine.move_to("2023-01-01")
+            """,
+        )
+
+    def test_pytestmark_module_freezer_fixture_defined_after(self):
+        check_transformed(
+            """
+            import pytest
+
+            def test_function(freezer):
+                freezer.move_to("2023-01-01")
+
+            pytestmark = pytest.mark.freeze_time("2000-01-01")
+            """,
+            """
+            import pytest
+
+            def test_function(time_machine):
+                time_machine.move_to("2023-01-01")
+
+            pytestmark = pytest.mark.time_machine("2000-01-01", tick=False)
+            """,
+        )
+
+    def test_pytestmark_class_freezer_fixture(self):
+        check_transformed(
+            """
+            import pytest
+
+            class TestSomething:
+                pytestmark = [pytest.mark.freeze_time("2000-01-01")]
+
+                def test_function(self, freezer):
+                    freezer.move_to("2023-01-01")
+            """,
+            """
+            import pytest
+
+            class TestSomething:
+                pytestmark = [pytest.mark.time_machine("2000-01-01", tick=False)]
+
+                def test_function(self, time_machine):
+                    time_machine.move_to("2023-01-01")
+            """,
+        )
+
     def test_freezer_fixture(self):
         check_transformed(
             """

--- a/tests/test_cli_fuzz.py
+++ b/tests/test_cli_fuzz.py
@@ -97,6 +97,22 @@ def decorators(draw: st.DrawFn) -> str:
 
 
 @st.composite
+def pytestmark_statements(draw: st.DrawFn) -> str:
+    markers = draw(
+        st.lists(
+            calls("pytest.mark.freeze_time", freeze_time_arglists)
+            | st.sampled_from(["pytest.mark.freeze_time", "pytest.mark.django_db"]),
+            min_size=1,
+            max_size=2,
+        )
+    )
+    if len(markers) == 1 and draw(st.booleans()):
+        return f"pytestmark = {markers[0]}"
+    wrapper = draw(st.sampled_from(["[{}]", "({},)"]))
+    return "pytestmark = " + wrapper.format(", ".join(markers))
+
+
+@st.composite
 def method_statements(draw: st.DrawFn) -> str:
     receiver = draw(st.sampled_from(["freezer", "t", "ft", "tick", "other"]))
     kind = draw(st.sampled_from(["call", "call", "call", "attribute", "reference"]))
@@ -160,7 +176,13 @@ def class_defs(draw: st.DrawFn) -> str:
     lines = draw(st.lists(decorators(), max_size=1))
     bases = draw(st.sampled_from(["", "(unittest.TestCase)", "(TestBase)"]))
     lines.append(f"class TestSomething{bases}:")
-    body = draw(st.lists(st.just("pass") | function_defs(), min_size=1, max_size=2))
+    body = draw(
+        st.lists(
+            st.just("pass") | pytestmark_statements() | function_defs(),
+            min_size=1,
+            max_size=2,
+        )
+    )
     lines.extend(indent(s) for s in body)
     return "\n".join(lines)
 
@@ -186,7 +208,8 @@ def modules(draw: st.DrawFn) -> str:
                 function_defs()
                 | class_defs()
                 | with_statements()
-                | method_statements(),
+                | method_statements()
+                | pytestmark_statements(),
                 min_size=1,
                 max_size=3,
             )


### PR DESCRIPTION
Migrate `pytest.mark.freeze_time` markers assigned to `pytestmark` at module or class level, whether assigned alone or within a list or tuple of markers.
Functions using the `freezer` fixture under such a `pytestmark` inherit its tick behaviour, as for the decorator form.
