### PR TITLE
Extend Migration CLI to drop `tz_offset=0`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,9 @@ Unreleased
 
 * Extend the :ref:`Migration CLI <migration-cli>` to migrate the ``pytest.mark.freeze_time`` marker in module-level and class-level ``pytestmark`` assignments.
 
+* Extend the :ref:`Migration CLI <migration-cli>` to migrate ``freeze_time()`` calls and markers that pass ``tz_offset`` with a literal zero value.
+  The argument is dropped, since a zero offset has no effect.
+
 3.4.0 (2026-08-10)
 ------------------
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -89,8 +89,9 @@ The changes the tool makes are:
 * ``from freezegun import freeze_time, FakeDate`` -> ``import time_machine`` plus ``from freezegun import FakeDate``, keeping the other imported names.
 
 * In function decorators, class decorators, and context managers: ``freeze_time(...)`` -> ``travel(...)``.
-  This change is applied only when ``freeze_time()`` is called with a single positional argument and up to one keyword argument, ``tick``.
+  This change is applied only when ``freeze_time()`` is called with a single positional argument and only supported keyword arguments: ``tick``, and ``tz_offset`` with a literal zero value.
   If ``tick`` is passed, it is kept as-is, otherwise it is replaced with ``tick=False`` (matching freezegun’s default behaviour).
+  ``tz_offset=0`` is dropped, since a zero offset has no effect.
 
 * In context managers that bind the result with ``as``, additionally: calls of the bound variable’s ``tick()`` method -> ``shift()``, with freezegun’s default delta of one second made explicit, for example ``ft.tick()`` -> ``ft.shift(1)``.
   Calls of the ``move_to()`` method are left unchanged, since it behaves the same in both libraries.

--- a/src/time_machine/cli.py
+++ b/src/time_machine/cli.py
@@ -383,6 +383,7 @@ def maybe_migrate_call(
     ret[ast_start_offset(func)].append(partial(switch_to_travel, node=func))
     if not any(kw.arg == "tick" for kw in node.keywords):
         ret[ast_start_offset(node)].append(partial(add_tick_false, node=node))
+    remove_droppable_kwargs(ret, node)
     return True
 
 
@@ -475,13 +476,35 @@ def maybe_migrate_marker(
     ret[ast_start_offset(node.func)].append(partial(switch_to_marker, node=node.func))
     if not any(kw.arg == "tick" for kw in node.keywords):
         ret[ast_start_offset(node)].append(partial(add_tick_false, node=node))
+    remove_droppable_kwargs(ret, node)
     return True
 
 
+def remove_droppable_kwargs(
+    ret: MutableMapping[Offset, list[TokenFunc]],
+    node: ast.Call,
+) -> None:
+    for kw in node.keywords:
+        if droppable_kwarg(kw):
+            ret[ast_start_offset(kw)].append(partial(remove_kwarg, node=kw))
+
+
 def migratable_call(node: ast.Call) -> bool:
-    return len(node.args) == 1 and (
-        len(node.keywords) == 0
-        or (len(node.keywords) == 1 and node.keywords[0].arg == "tick")
+    return len(node.args) == 1 and all(
+        kw.arg == "tick" or droppable_kwarg(kw) for kw in node.keywords
+    )
+
+
+def droppable_kwarg(kw: ast.keyword) -> bool:
+    """
+    Check if the given freeze_time() keyword argument can be dropped when
+    migrating, because its value makes it have no effect.
+    """
+    return (
+        kw.arg == "tz_offset"
+        and isinstance(kw.value, ast.Constant)
+        and type(kw.value.value) in (int, float)
+        and kw.value.value == 0
     )
 
 
@@ -668,6 +691,18 @@ def replace_tick_with_shift(tokens: list[Token], i: int, node: ast.Call) -> None
         while tokens[i].src != "(":
             i += 1
         tokens.insert(i + 1, Token(name=CODE, src="1"))
+
+
+def remove_kwarg(tokens: list[Token], i: int, node: ast.keyword) -> None:
+    """
+    Remove the given keyword argument, along with the comma that precedes it.
+    """
+    j = find_last_token(tokens, i, node=node)
+    k = i - 1
+    while tokens[k].name in NON_CODING_TOKENS:
+        k -= 1
+    assert tokens[k].src == ","
+    del tokens[k : j + 1]
 
 
 def add_tick_false(tokens: list[Token], i: int, node: ast.Call) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -456,6 +456,207 @@ class TestMigrateContents:
             """,
         )
 
+    def test_function_decorator_tz_offset_zero(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            @freeze_time("2023-01-01", tz_offset=0)
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel("2023-01-01", tick=False)
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_function_decorator_tz_offset_zero_float(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            @freeze_time("2023-01-01", tz_offset=0.0)
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel("2023-01-01", tick=False)
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_function_decorator_tz_offset_zero_before_tick(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            @freeze_time("2023-01-01", tz_offset=0, tick=True)
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel("2023-01-01", tick=True)
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_function_decorator_tz_offset_zero_after_tick(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            @freeze_time("2023-01-01", tick=True, tz_offset=0)
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel("2023-01-01", tick=True)
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_function_decorator_tz_offset_zero_trailing_comma(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            @freeze_time("2023-01-01", tz_offset=0,)
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel("2023-01-01", tick=False)
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_function_decorator_tz_offset_zero_multiline(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            @freeze_time(
+                "2023-01-01",
+                tz_offset=0,
+            )
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel(
+                "2023-01-01", tick=False
+            )
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_function_decorator_tz_offset_nonzero(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            @freeze_time("2023-01-01", tz_offset=-4)
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @freeze_time("2023-01-01", tz_offset=-4)
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_function_decorator_tz_offset_false(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            @freeze_time("2023-01-01", tz_offset=False)
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @freeze_time("2023-01-01", tz_offset=False)
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_function_decorator_tz_offset_variable(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            @freeze_time("2023-01-01", tz_offset=offset)
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @freeze_time("2023-01-01", tz_offset=offset)
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_with_tz_offset_zero(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            with freeze_time("2023-01-01", tz_offset=0):
+                pass
+            """,
+            """
+            import time_machine
+
+            with time_machine.travel("2023-01-01", tick=False):
+                pass
+            """,
+        )
+
+    def test_marker_tz_offset_zero(self):
+        check_transformed(
+            """
+            import pytest
+
+            @pytest.mark.freeze_time("2023-01-01", tz_offset=0)
+            def test_function():
+                pass
+            """,
+            """
+            import pytest
+
+            @pytest.mark.time_machine("2023-01-01", tick=False)
+            def test_function():
+                pass
+            """,
+        )
+
     def test_function_decorator_name_unrelated(self):
         check_noop(
             """

--- a/tests/test_cli_fuzz.py
+++ b/tests/test_cli_fuzz.py
@@ -42,6 +42,9 @@ freeze_time_arglists = st.sampled_from(
         ('"2023-01-01"', "tick=True"),
         ('"2023-01-01"', "tick=False"),
         ('"2023-01-01"', "auto_tick_seconds=1"),
+        ('"2023-01-01"', "tz_offset=0"),
+        ('"2023-01-01"', "tz_offset=-4"),
+        ('"2023-01-01"', "tz_offset=0", "tick=True"),
     ]
 )
 


### PR DESCRIPTION
Migrate `freeze_time()` calls and `pytest.mark.freeze_time` markers that pass `tz_offset` as a literal zero, dropping the argument since a zero offset has no effect.
