### PR TITLE
Support destination of `None`, meaning the current time

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ----------
 
+* Support ``None`` as a destination for ``travel()`` and ``Traveller.move_to()``, meaning the current time.
+  Use this with ``tick=False`` to freeze time at the present moment, matching freezegun’s behaviour when ``freeze_time()`` is called with no arguments.
+
 * Extend the :ref:`Migration CLI <migration-cli>` to migrate aliased imports: ``import freezegun as fg`` and ``from freezegun import freeze_time as ft``, plus calls using such aliases.
 
 * Extend the :ref:`Migration CLI <migration-cli>` to migrate the ``pytest.mark.freeze_time`` marker in module-level and class-level ``pytestmark`` assignments.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -80,6 +80,10 @@ Main API
     .. |dateutil.parse()| replace:: ``dateutil.parse()``
     __ https://dateutil.readthedocs.io/en/stable/parser.html
 
+  * ``None``, meaning the current time.
+    Use this with ``tick=False`` to freeze time at the present moment.
+    If already time travelling, the current time is the mocked one, as with a ``datetime.timedelta`` destination.
+
   Additionally, you can provide some more complex types:
 
   * A generator, in which case ``next()`` will be called on it, with the result treated as above.

--- a/src/time_machine/__init__.py
+++ b/src/time_machine/__init__.py
@@ -83,7 +83,7 @@ def _reset_uuid_timestamps() -> None:
 
 
 DestinationBaseType: TypeAlias = (
-    int | float | dt.datetime | dt.timedelta | dt.date | str
+    int | float | dt.datetime | dt.timedelta | dt.date | str | None
 )
 DestinationType: TypeAlias = (
     DestinationBaseType
@@ -136,7 +136,9 @@ def extract_timestamp_tzname(
 
     timestamp_ns: int
     tzname: str | None = None
-    if isinstance(dest, int):
+    if dest is None:
+        timestamp_ns = time_module.time_ns()
+    elif isinstance(dest, int):
         timestamp_ns = dest * NANOSECONDS_PER_SECOND
     elif isinstance(dest, float):
         timestamp_ns = round(dest * NANOSECONDS_PER_SECOND)

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -654,6 +654,20 @@ def test_destination_date():
     assert time.time() == EPOCH
 
 
+def test_destination_none():
+    now = time.time()
+    with time_machine.travel(None, tick=False):
+        assert now <= time.time() <= now + 1.0
+
+
+def test_destination_none_nested():
+    with (
+        time_machine.travel(EPOCH, tick=False),
+        time_machine.travel(None, tick=False),
+    ):
+        assert time.time() == EPOCH
+
+
 def test_destination_timedelta():
     now = time.time()
     with time_machine.travel(dt.timedelta(seconds=3600)):


### PR DESCRIPTION
Allow `travel(None)` and `Traveller.move_to(None)`, travelling to the current time, matching freezegun's behaviour when `freeze_time()` is called with no arguments.
