### PR TITLE
Extend Migration CLI to migrate `freeze_time()` calls with no destination

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,9 @@ Unreleased
 * Extend the :ref:`Migration CLI <migration-cli>` to migrate ``freeze_time()`` calls and markers that pass ``real_asyncio``.
   The argument is dropped, whatever its value, since time-machine does not mock ``time.monotonic()``, so asyncio event loops always see real time.
 
+* Extend the :ref:`Migration CLI <migration-cli>` to migrate ``freeze_time()`` calls and markers with no destination argument, which freeze at the current time.
+  ``None`` is added as the destination, using the new support for ``None`` destinations (above).
+
 3.4.0 (2026-08-10)
 ------------------
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -91,6 +91,7 @@ The changes the tool makes are:
 * In function decorators, class decorators, and context managers: ``freeze_time(...)`` -> ``travel(...)``.
   This change is applied only when ``freeze_time()`` is called with a single positional argument and only supported keyword arguments: ``tick``, ``tz_offset`` with a literal zero value, and ``real_asyncio``.
   If ``tick`` is passed, it is kept as-is, otherwise it is replaced with ``tick=False`` (matching freezegun’s default behaviour).
+  If no positional argument is passed, ``None`` is added as the destination, meaning the current time, matching freezegun’s behaviour of freezing at the current time.
   ``tz_offset=0`` is dropped, since a zero offset has no effect.
   ``real_asyncio`` is dropped, whatever its value, since time-machine does not mock ``time.monotonic()``, so asyncio event loops always see real time.
 

--- a/src/time_machine/cli.py
+++ b/src/time_machine/cli.py
@@ -381,9 +381,7 @@ def maybe_migrate_call(
         return False
 
     ret[ast_start_offset(func)].append(partial(switch_to_travel, node=func))
-    if not any(kw.arg == "tick" for kw in node.keywords):
-        ret[ast_start_offset(node)].append(partial(add_tick_false, node=node))
-    remove_droppable_kwargs(ret, node)
+    migrate_arguments(ret, node)
     return True
 
 
@@ -474,23 +472,34 @@ def maybe_migrate_marker(
         return False
 
     ret[ast_start_offset(node.func)].append(partial(switch_to_marker, node=node.func))
-    if not any(kw.arg == "tick" for kw in node.keywords):
-        ret[ast_start_offset(node)].append(partial(add_tick_false, node=node))
-    remove_droppable_kwargs(ret, node)
+    migrate_arguments(ret, node)
     return True
 
 
-def remove_droppable_kwargs(
+def migrate_arguments(
     ret: MutableMapping[Offset, list[TokenFunc]],
     node: ast.Call,
 ) -> None:
+    """
+    Add the callbacks to adjust the arguments of a migratable freeze_time()
+    call: add a None destination if there is no positional argument, add
+    tick=False if tick is not passed, and remove droppable keyword arguments.
+    """
+    if not node.args:
+        tick_kwargs = [kw for kw in node.keywords if kw.arg == "tick"]
+        if tick_kwargs:
+            ret[ast_start_offset(tick_kwargs[0])].append(insert_none_arg)
+        else:
+            ret[ast_start_offset(node)].append(partial(add_none_arg, node=node))
+    if not any(kw.arg == "tick" for kw in node.keywords):
+        ret[ast_start_offset(node)].append(partial(add_tick_false, node=node))
     for kw in node.keywords:
         if droppable_kwarg(kw):
             ret[ast_start_offset(kw)].append(partial(remove_kwarg, node=kw))
 
 
 def migratable_call(node: ast.Call) -> bool:
-    return len(node.args) == 1 and all(
+    return len(node.args) <= 1 and all(
         kw.arg == "tick" or droppable_kwarg(kw) for kw in node.keywords
     )
 
@@ -704,14 +713,45 @@ def replace_tick_with_shift(tokens: list[Token], i: int, node: ast.Call) -> None
 
 def remove_kwarg(tokens: list[Token], i: int, node: ast.keyword) -> None:
     """
-    Remove the given keyword argument, along with the comma that precedes it.
+    Remove the given keyword argument, along with the comma that precedes it,
+    or, for a first argument, any comma and space that follow it.
     """
     j = find_last_token(tokens, i, node=node)
     k = i - 1
     while tokens[k].name in NON_CODING_TOKENS:
         k -= 1
-    assert tokens[k].src == ","
-    del tokens[k : j + 1]
+    if tokens[k].src == ",":
+        del tokens[k : j + 1]
+        return
+    k = j + 1
+    while tokens[k].name in NON_CODING_TOKENS:
+        k += 1
+    if tokens[k].src == ",":
+        j = k
+        if tokens[j + 1].name == UNIMPORTANT_WS:
+            j += 1
+    del tokens[i : j + 1]
+
+
+def insert_none_arg(tokens: list[Token], i: int) -> None:
+    """
+    Insert a `None` argument before the token at the given index, the start of
+    the call’s tick keyword argument.
+    """
+    tokens.insert(i, Token(name=CODE, src="None, "))
+
+
+def add_none_arg(tokens: list[Token], i: int, node: ast.Call) -> None:
+    """
+    Add a `None` argument to the function call, which has no remaining
+    arguments, since any droppable keyword arguments were already removed.
+    """
+    j = find_last_token(tokens, i, node=node)
+    k = j - 1
+    while tokens[k].name in NON_CODING_TOKENS:
+        k -= 1
+    assert tokens[k].src == "("
+    tokens.insert(k + 1, Token(name=CODE, src="None"))
 
 
 def add_tick_false(tokens: list[Token], i: int, node: ast.Call) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -456,6 +456,202 @@ class TestMigrateContents:
             """,
         )
 
+    def test_function_decorator_no_arguments(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            @freeze_time()
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel(None, tick=False)
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_function_decorator_no_arguments_attr(self):
+        check_transformed(
+            """
+            import freezegun
+
+            @freezegun.freeze_time()
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel(None, tick=False)
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_function_decorator_no_arguments_tick(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            @freeze_time(tick=True)
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel(None, tick=True)
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_function_decorator_no_arguments_tz_offset_zero(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            @freeze_time(tz_offset=0)
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel(None, tick=False)
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_function_decorator_no_arguments_tz_offset_zero_trailing_comma(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            @freeze_time(tz_offset=0,)
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel(None, tick=False)
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_function_decorator_no_arguments_tz_offset_zero_before_tick(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            @freeze_time(tz_offset=0, tick=True)
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel(None, tick=True)
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_function_decorator_no_arguments_tz_offset_zero_after_tick(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            @freeze_time(tick=True, tz_offset=0)
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel(None, tick=True)
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_function_decorator_no_arguments_tz_offset_zero_spaced(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            @freeze_time( tz_offset=0 , tick=True )
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel( None, tick=True )
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_function_decorator_no_arguments_tz_offset_zero_only_spaced(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            @freeze_time( tz_offset=0 )
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel(None  , tick=False)
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_with_no_arguments(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            with freeze_time() as ft:
+                ft.tick()
+            """,
+            """
+            import time_machine
+
+            with time_machine.travel(None, tick=False) as ft:
+                ft.shift(1)
+            """,
+        )
+
+    def test_marker_no_arguments(self):
+        check_transformed(
+            """
+            import pytest
+
+            @pytest.mark.freeze_time()
+            def test_function():
+                pass
+            """,
+            """
+            import pytest
+
+            @pytest.mark.time_machine(None, tick=False)
+            def test_function():
+                pass
+            """,
+        )
+
     def test_function_decorator_tz_offset_zero(self):
         check_transformed(
             """


### PR DESCRIPTION
Migrate `freeze_time()` calls and `pytest.mark.freeze_time` markers with no destination argument, which freeze at the current time, adding `None` as the destination.
