### PR TITLE
Make Migration CLI report unmigrated freezegun usages

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,15 @@ Unreleased
 * Extend the :ref:`Migration CLI <migration-cli>` to migrate ``freeze_time()`` calls and markers with no destination argument, which freeze at the current time.
   ``None`` is added as the destination, using the new support for ``None`` destinations (above).
 
+
+* Make the :ref:`Migration CLI <migration-cli>` report freezegun-related usages that it recognizes but cannot migrate, with their positions, like:
+
+  .. code-block:: console
+
+    example/tests.py:9:2: freeze_time usage not migrated
+
+  This makes it easier to find and fix the remaining usages manually.
+
 3.4.0 (2026-08-10)
 ------------------
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -35,6 +35,15 @@ Migration CLI
 time-machine comes with a command-line interface to help you migrate from freezegun.
 It performs partial replacements on your code to update it to use time-machine's API.
 It may leave your code in a broken state, for example where an import of ``freezegun`` has been replaced but calls using it remain—it’s recommended you have a good linting setup to find these, and then you can manually fix them up.
+To help with this, the tool reports freezegun-related usages that it recognizes but cannot migrate, with their positions:
+
+.. code-block:: console
+
+    $ python -m time_machine migrate example/tests.py
+    Rewriting example/tests.py
+    example/tests.py:9:2: freeze_time usage not migrated
+
+These reports are heuristic and may occasionally flag unrelated code that reuses a freezegun-related name, such as a function parameter that shadows an imported ``freeze_time``.
 
 The tool edits files in place, reporting those that it changes.
 It’s recommended you start from a clean, committed state in your version control system, so you can easily revert any broken changes.

--- a/src/time_machine/cli.py
+++ b/src/time_machine/cli.py
@@ -7,6 +7,7 @@ import warnings
 from collections import defaultdict
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from functools import partial
+from typing import NamedTuple
 
 from tokenize_rt import (
     NON_CODING_TOKENS,
@@ -65,7 +66,7 @@ def migrate_file(filename: str) -> int:
         print(f"{filename} is non-utf-8 (not supported)")
         return 1
 
-    contents_text = migrate_contents(contents_text)
+    contents_text, reports = migrate_contents(contents_text)
 
     if filename == "-":
         print(contents_text, end="")
@@ -74,20 +75,34 @@ def migrate_file(filename: str) -> int:
         with open(filename, "w", encoding="UTF-8", newline="") as f:
             f.write(contents_text)
 
+    for report in reports:
+        print(
+            f"{filename}:{report.lineno}:{report.col}: {report.message}",
+            file=sys.stderr,
+        )
+
     return contents_text != contents_text_orig
 
 
-def migrate_contents(contents_text: str) -> str:
+class Report(NamedTuple):
+    """A freezegun-related usage that could not be migrated."""
+
+    lineno: int
+    col: int
+    message: str
+
+
+def migrate_contents(contents_text: str) -> tuple[str, list[Report]]:
     """Migrate a single text from freezegun to time-machine."""
     try:
         ast_obj = ast_parse(contents_text)
     except SyntaxError:
-        return contents_text
+        return contents_text, []
 
-    callbacks = visit(ast_obj)
+    callbacks, reports = visit(ast_obj)
 
     if not callbacks:
-        return contents_text
+        return contents_text, reports
 
     tokens = src_to_tokens(contents_text)
 
@@ -102,7 +117,8 @@ def migrate_contents(contents_text: str) -> str:
             callback(tokens, i)
 
     # no types for tokenize-rt
-    return tokens_to_src(tokens)  # type: ignore [no-any-return]
+    new_text: str = tokens_to_src(tokens)
+    return new_text, reports
 
 
 def ast_parse(contents_text: str) -> ast.Module:
@@ -162,13 +178,17 @@ class TravellerVar:
         self.end_lineno = node.end_lineno
 
 
-def visit(tree: ast.Module) -> Mapping[Offset, list[TokenFunc]]:
+def visit(
+    tree: ast.Module,
+) -> tuple[Mapping[Offset, list[TokenFunc]], list[Report]]:
     """
-    Visit the AST and return a list of callbacks to apply to the tokens.
+    Visit the AST and return a mapping of callbacks to apply to the tokens,
+    plus reports of freezegun-related usages that could not be migrated.
     """
     ret: defaultdict[Offset, list[TokenFunc]] = defaultdict(list)
     freezegun_module_names: set[str] = set()
     freeze_time_names: set[str] = set()
+    report_module_names: set[str] = set()
     freezer_functions: list[FreezerFunction] = []
     marker_class_methods: set[ast.FunctionDef | ast.AsyncFunctionDef] = set()
     module_marker_seen = False
@@ -179,15 +199,27 @@ def visit(tree: ast.Module) -> Mapping[Offset, list[TokenFunc]]:
                 for stmt in node.body:
                     if maybe_migrate_pytestmark(ret, stmt):
                         module_marker_seen = True
-            case ast.Import() if (
-                len(node.names) == 1 and (alias := node.names[0]).name == "freezegun"
-            ):
-                freezegun_module_names.add(alias.asname or "freezegun")
-                if alias.asname is None:
-                    ret[ast_start_offset(node)].append(replace_import)
+            case ast.Import():
+                if (
+                    len(node.names) == 1
+                    and (alias := node.names[0]).name == "freezegun"
+                ):
+                    freezegun_module_names.add(alias.asname or "freezegun")
+                    if alias.asname is None:
+                        ret[ast_start_offset(node)].append(replace_import)
+                    else:
+                        ret[ast_start_offset(node)].append(
+                            partial(replace_aliased_import, node=node)
+                        )
                 else:
-                    ret[ast_start_offset(node)].append(
-                        partial(replace_aliased_import, node=node)
+                    # Imports of freezegun that cannot be migrated, like
+                    # `import freezegun, os` or `import freezegun.config`,
+                    # still have their bound names tracked for reporting.
+                    report_module_names.update(
+                        alias.asname or "freezegun"
+                        for alias in node.names
+                        if alias.name == "freezegun"
+                        or alias.name.startswith("freezegun.")
                     )
             case ast.ImportFrom() if (
                 node.level == 0
@@ -331,7 +363,38 @@ def visit(tree: ast.Module) -> Mapping[Offset, list[TokenFunc]]:
                         partial(add_tick_false, node=node)
                     )
 
-    return ret
+    reports = []
+    for node in ast.walk(tree):
+        match node:
+            case ast.Name(id=name) if (
+                name in freeze_time_names
+                or name in freezegun_module_names
+                or name in report_module_names
+            ) and ast_start_offset(node) not in ret:
+                reports.append(
+                    Report(
+                        node.lineno,
+                        node.col_offset + 1,
+                        f"{name} usage not migrated",
+                    )
+                )
+            case ast.Attribute(
+                attr="freeze_time",
+                value=ast.Attribute(
+                    attr="mark",
+                    value=ast.Name(id="pytest"),
+                ),
+            ) if ast_start_offset(node) not in ret:
+                reports.append(
+                    Report(
+                        node.lineno,
+                        node.col_offset + 1,
+                        "pytest.mark.freeze_time usage not migrated",
+                    )
+                )
+    reports.sort()
+
+    return ret, reports
 
 
 def find_freezer_function(
@@ -485,13 +548,13 @@ def migrate_arguments(
     call: add a None destination if there is no positional argument, add
     tick=False if tick is not passed, and remove droppable keyword arguments.
     """
+    tick_kwargs = [kw for kw in node.keywords if kw.arg == "tick"]
     if not node.args:
-        tick_kwargs = [kw for kw in node.keywords if kw.arg == "tick"]
         if tick_kwargs:
             ret[ast_start_offset(tick_kwargs[0])].append(insert_none_arg)
         else:
             ret[ast_start_offset(node)].append(partial(add_none_arg, node=node))
-    if not any(kw.arg == "tick" for kw in node.keywords):
+    if not tick_kwargs:
         ret[ast_start_offset(node)].append(partial(add_tick_false, node=node))
     for kw in node.keywords:
         if droppable_kwarg(kw):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -135,18 +135,49 @@ class TestMain:
         assert out == "import time_machine\n"
         assert err == ""
 
+    def test_migrate_reports(self, capsys, tmp_path):
+        path = tmp_path / "example.py"
+        path.write_text(
+            "from freezegun import freeze_time\n"
+            "@freeze_time\n"
+            "def test_function():\n"
+            "    pass\n"
+        )
 
-def check_noop(given: str) -> None:
+        result = main(["migrate", str(path)])
+
+        assert result == 1
+        out, err = capsys.readouterr()
+        assert out == ""
+        assert err == (
+            f"Rewriting {path}\n" + f"{path}:2:2: freeze_time usage not migrated\n"
+        )
+
+        assert path.read_text() == (
+            "import time_machine\n@freeze_time\ndef test_function():\n    pass\n"
+        )
+
+
+def check_noop(
+    given: str,
+    reports: list[tuple[int, int, str]] | None = None,
+) -> None:
     given = dedent(given)
-    result = migrate_contents(given)
+    result, result_reports = migrate_contents(given)
     assert result == given
+    assert result_reports == (reports or [])
 
 
-def check_transformed(given: str, expected: str) -> None:
+def check_transformed(
+    given: str,
+    expected: str,
+    reports: list[tuple[int, int, str]] | None = None,
+) -> None:
     given = dedent(given)
     expected = dedent(expected)
-    result = migrate_contents(given)
+    result, result_reports = migrate_contents(given)
     assert result == expected
+    assert result_reports == (reports or [])
 
 
 class TestMigrateContents:
@@ -382,6 +413,7 @@ class TestMigrateContents:
             def test_function():
                 pass
             """,
+            reports=[(4, 2, "freezegun usage not migrated")],
         )
 
     def test_function_decorator_attr(self):
@@ -781,6 +813,7 @@ class TestMigrateContents:
             def test_function():
                 pass
             """,
+            reports=[(4, 2, "freeze_time usage not migrated")],
         )
 
     def test_function_decorator_tz_offset_false(self):
@@ -799,6 +832,7 @@ class TestMigrateContents:
             def test_function():
                 pass
             """,
+            reports=[(4, 2, "freeze_time usage not migrated")],
         )
 
     def test_function_decorator_tz_offset_variable(self):
@@ -817,6 +851,7 @@ class TestMigrateContents:
             def test_function():
                 pass
             """,
+            reports=[(4, 2, "freeze_time usage not migrated")],
         )
 
     def test_function_decorator_real_asyncio_true(self):
@@ -934,6 +969,7 @@ class TestMigrateContents:
             def test_function():
                 pass
             """,
+            reports=[(4, 2, "freeze_time usage not migrated")],
         )
 
     def test_function_decorator_name(self):
@@ -1057,6 +1093,7 @@ class TestMigrateContents:
             class TestClass:
                 pass
             """,
+            reports=[(4, 2, "freezegun usage not migrated")],
         )
 
     def test_class_decorator_attr_not_unittest_class(self):
@@ -1075,6 +1112,7 @@ class TestMigrateContents:
             class TestClass:
                 pass
             """,
+            reports=[(4, 2, "freezegun usage not migrated")],
         )
 
     def test_class_decorator_attr_unittest_class_base_name(self):
@@ -1234,6 +1272,7 @@ class TestMigrateContents:
             class TestClass:
                 pass
             """,
+            reports=[(4, 2, "freeze_time usage not migrated")],
         )
 
     def test_class_decorator_name_not_unittest_class(self):
@@ -1252,6 +1291,7 @@ class TestMigrateContents:
             class TestClass:
                 pass
             """,
+            reports=[(4, 2, "freeze_time usage not migrated")],
         )
 
     def test_class_decorator_name_unittest_class_base_name(self):
@@ -1362,6 +1402,7 @@ class TestMigrateContents:
             with freezegun.freeze_time:
                 pass
             """,
+            reports=[(4, 6, "freezegun usage not migrated")],
         )
 
     def test_with_attr_as(self):
@@ -1436,6 +1477,7 @@ class TestMigrateContents:
             with freeze_time:
                 pass
             """,
+            reports=[(4, 6, "freeze_time usage not migrated")],
         )
 
     def test_with_name_as(self):
@@ -1500,6 +1542,7 @@ class TestMigrateContents:
             with freeze_time("2023-01-01") as obj.ft:
                 pass
             """,
+            reports=[(4, 6, "freeze_time usage not migrated")],
         )
 
     def test_with_as_tick(self):
@@ -1604,6 +1647,7 @@ class TestMigrateContents:
             with freeze_time("2023-01-01") as ft:
                 now = ft.tick()
             """,
+            reports=[(4, 6, "freeze_time usage not migrated")],
         )
 
     def test_with_as_incompatible_attribute(self):
@@ -1620,6 +1664,7 @@ class TestMigrateContents:
             with freeze_time("2023-01-01") as ft:
                 assert ft.time_to_freeze.year == 2023
             """,
+            reports=[(4, 6, "freeze_time usage not migrated")],
         )
 
     def test_with_as_incompatible_reference(self):
@@ -1636,6 +1681,7 @@ class TestMigrateContents:
             with freeze_time("2023-01-01") as ft:
                 helper(ft)
             """,
+            reports=[(4, 6, "freeze_time usage not migrated")],
         )
 
     def test_with_as_unmigratable_call(self):
@@ -1652,6 +1698,7 @@ class TestMigrateContents:
             with freeze_time("2023-01-01", auto_tick_seconds=1) as ft:
                 ft.tick()
             """,
+            reports=[(4, 6, "freeze_time usage not migrated")],
         )
 
     def test_marker(self):
@@ -1717,6 +1764,7 @@ class TestMigrateContents:
             def test_function():
                 pass
             """,
+            reports=[(4, 2, "pytest.mark.freeze_time usage not migrated")],
         )
 
     def test_marker_unmigratable_call(self):
@@ -1728,6 +1776,7 @@ class TestMigrateContents:
             def test_function():
                 pass
             """,
+            reports=[(4, 2, "pytest.mark.freeze_time usage not migrated")],
         )
 
     def test_marker_unrelated(self):
@@ -1839,6 +1888,7 @@ class TestMigrateContents:
 
             pytestmark = pytest.mark.freeze_time
             """,
+            reports=[(4, 14, "pytest.mark.freeze_time usage not migrated")],
         )
 
     def test_pytestmark_module_other_value(self):
@@ -1924,6 +1974,68 @@ class TestMigrateContents:
                 def test_function(self, time_machine):
                     time_machine.move_to("2023-01-01")
             """,
+        )
+
+    def test_reports_import_multiple(self):
+        check_noop(
+            """
+            import freezegun, os
+
+            @freezegun.freeze_time("2023-01-01")
+            def test_function():
+                pass
+            """,
+            reports=[(4, 2, "freezegun usage not migrated")],
+        )
+
+    def test_reports_import_dotted(self):
+        check_noop(
+            """
+            import freezegun.config
+
+            freezegun.config.configure(extend_ignore_list=["tensorflow"])
+            """,
+            reports=[(4, 1, "freezegun usage not migrated")],
+        )
+
+    def test_reports_import_dotted_aliased(self):
+        check_noop(
+            """
+            import freezegun.api as fg_api
+
+            x = fg_api.FakeDatetime(2020, 1, 1)
+            """,
+            reports=[(4, 5, "fg_api usage not migrated")],
+        )
+
+    def test_reports_sorted(self):
+        check_transformed(
+            """
+            import freezegun
+
+            @freezegun.freeze_time
+            def test_one():
+                pass
+
+            def test_two():
+                with freezegun.freeze_time("2023-01-01") as ft:
+                    helper(ft)
+            """,
+            """
+            import time_machine
+
+            @freezegun.freeze_time
+            def test_one():
+                pass
+
+            def test_two():
+                with freezegun.freeze_time("2023-01-01") as ft:
+                    helper(ft)
+            """,
+            reports=[
+                (4, 2, "freezegun usage not migrated"),
+                (9, 10, "freezegun usage not migrated"),
+            ],
         )
 
     def test_freezer_fixture(self):
@@ -2084,6 +2196,7 @@ class TestMigrateContents:
                 with freeze_time("2024-01-01"):
                     pass
             """,
+            reports=[(6, 10, "freeze_time usage not migrated")],
         )
 
     def test_freezer_fixture_no_argument_noop(self):

--- a/tests/test_cli_fuzz.py
+++ b/tests/test_cli_fuzz.py
@@ -228,10 +228,10 @@ def modules(draw: st.DrawFn) -> str:
 def test_migrate_contents_properties(source: str) -> None:
     ast.parse(source)  # the grammar should only generate valid code
 
-    migrated = migrate_contents(source)  # must not crash
+    migrated, _ = migrate_contents(source)  # must not crash
 
     # the output must still be valid Python
     ast.parse(migrated)
 
     # migration must be idempotent
-    assert migrate_contents(migrated) == migrated
+    assert migrate_contents(migrated)[0] == migrated


### PR DESCRIPTION
After rewriting, report freezegun-related usages that the tool recognizes but cannot migrate, with their positions, like `example/tests.py:9:2: freeze_time usage not migrated`, so they are easier to find and fix manually.
