### PR TITLE
Extend Migration CLI to migrate raw-use `start()`/`stop()` assignments

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -30,6 +30,8 @@ Unreleased
 
   This makes it easier to find and fix the remaining usages manually.
 
+* Extend the :ref:`Migration CLI <migration-cli>` to migrate “raw use” assignments of ``freeze_time()`` to variables or ``self.`` attributes used with ``start()`` and ``stop()``, covering unittest ``setUp()`` / ``tearDown()`` patterns like ``self.freezer = freeze_time(...)`` with ``self.addCleanup(self.freezer.stop)``.
+
 3.4.0 (2026-08-10)
 ------------------
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -104,6 +104,11 @@ The changes the tool makes are:
   ``tz_offset=0`` is dropped, since a zero offset has no effect.
   ``real_asyncio`` is dropped, whatever its value, since time-machine does not mock ``time.monotonic()``, so asyncio event loops always see real time.
 
+* “Raw use” assignments that bind ``freeze_time()`` to a variable for later ``start()`` and ``stop()`` calls: the assigned call is migrated as above, since ``travel()`` instances have the same ``start()`` / ``stop()`` interface.
+  This applies to plain variables, like ``freezer = freeze_time(...)``, checked within the enclosing function or module, and to ``self.`` attributes, checked across the enclosing class, so unittest ``setUp()`` / ``tearDown()`` patterns are covered, including cleanup registrations like ``self.addCleanup(self.freezer.stop)``.
+  The migration only applies when the variable is used solely for ``start()`` and ``stop()``: as calls with no arguments in statements, or as bare references passed as call arguments.
+  Other uses, such as ``move_to()`` or ``tick()`` calls, prevent migration, since freezegun’s object has other methods with no equivalent on ``travel()``.
+
 * In context managers that bind the result with ``as``, additionally: calls of the bound variable’s ``tick()`` method -> ``shift()``, with freezegun’s default delta of one second made explicit, for example ``ft.tick()`` -> ``ft.shift(1)``.
   Calls of the ``move_to()`` method are left unchanged, since it behaves the same in both libraries.
   These changes are only applied when the bound variable is used solely for ``move_to()`` calls and ``tick()`` calls as statements, since ``tick()`` returns the new time whilst ``shift()`` returns ``None``, and other freezegun attributes have no equivalent on the object that ``travel()`` yields.

--- a/src/time_machine/cli.py
+++ b/src/time_machine/cli.py
@@ -5,7 +5,7 @@ import ast
 import sys
 import warnings
 from collections import defaultdict
-from collections.abc import Callable, Mapping, MutableMapping, Sequence
+from collections.abc import Callable, Generator, Mapping, MutableMapping, Sequence
 from functools import partial
 from typing import NamedTuple
 
@@ -363,6 +363,22 @@ def visit(
                         partial(add_tick_false, node=node)
                     )
 
+    for assignment, use_scope in find_candidate_assignments(tree):
+        target = assignment.targets[0]
+        if isinstance(target, ast.Name):
+            compatible = name_target_uses_compatible(use_scope, target)
+        else:
+            assert isinstance(target, ast.Attribute)
+            compatible = self_attr_target_uses_compatible(use_scope, target)
+        if compatible:
+            maybe_migrate_call(
+                ret,
+                assignment.value,
+                freezegun_module_names=freezegun_module_names,
+                freeze_time_names=freeze_time_names,
+                freezer_functions=freezer_functions,
+            )
+
     reports = []
     for node in ast.walk(tree):
         match node:
@@ -408,6 +424,127 @@ def find_freezer_function(
         if function.lineno <= node.lineno <= function.end_lineno:
             return function
     return None
+
+
+def find_candidate_assignments(
+    tree: ast.Module,
+) -> Generator[tuple[ast.Assign, ast.AST], None, None]:
+    """
+    Yield assignments of call results that may be freeze_time() calls bound
+    for "raw use" with start() and stop(), paired with the node to search for
+    uses of the bound name: the enclosing function or module for plain names,
+    or the enclosing class for `self.` attributes.
+    """
+
+    def recurse(
+        node: ast.AST, scope: ast.AST | None, class_node: ast.ClassDef | None
+    ) -> Generator[tuple[ast.Assign, ast.AST], None, None]:
+        for child in ast.iter_child_nodes(node):
+            match child:
+                case ast.Assign(
+                    targets=[ast.Name()],
+                    value=ast.Call(),
+                ) if scope is not None:
+                    yield (child, scope)
+                case ast.Assign(
+                    targets=[ast.Attribute(value=ast.Name(id="self"))],
+                    value=ast.Call(),
+                ) if class_node is not None:
+                    yield (child, class_node)
+
+            match child:
+                case ast.FunctionDef() | ast.AsyncFunctionDef():
+                    yield from recurse(child, child, class_node)
+                case ast.ClassDef():
+                    # Plain-name assignments directly in a class body are not
+                    # tracked, since their uses cannot be checked simply.
+                    yield from recurse(child, None, child)
+                case _:
+                    yield from recurse(child, scope, class_node)
+
+    yield from recurse(tree, tree, None)
+
+
+def name_target_uses_compatible(scope: ast.AST, target: ast.Name) -> bool:
+    """
+    Check that a plain variable assigned a freeze_time() call is only used in
+    ways that work the same on time-machine's travel(): start() and stop()
+    calls as statements, and bare start / stop references passed as call
+    arguments, like `atexit.register(freezer.stop)`.
+    """
+    name = target.id
+    allowed: set[ast.AST] = {target}
+    for subnode in ast.walk(scope):
+        match subnode:
+            case ast.Expr(
+                value=ast.Call(
+                    func=ast.Attribute(
+                        value=ast.Name(id=receiver) as receiver_node,
+                        attr="start" | "stop",
+                    ),
+                    args=[],
+                    keywords=[],
+                )
+            ) if receiver == name:
+                allowed.add(receiver_node)
+            case ast.Call(args=args):
+                for arg in args:
+                    match arg:
+                        case ast.Attribute(
+                            value=ast.Name(id=receiver) as receiver_node,
+                            attr="start" | "stop",
+                        ) if receiver == name:
+                            allowed.add(receiver_node)
+    return all(
+        subnode in allowed
+        for subnode in ast.walk(scope)
+        if isinstance(subnode, ast.Name) and subnode.id == name
+    )
+
+
+def self_attr_target_uses_compatible(scope: ast.AST, target: ast.Attribute) -> bool:
+    """
+    As for name_target_uses_compatible(), but for a `self.` attribute
+    assigned a freeze_time() call, checked across the enclosing class, so
+    unittest setUp() / tearDown() / addCleanup() patterns are covered.
+    """
+    name = target.attr
+    allowed: set[ast.AST] = {target}
+    for subnode in ast.walk(scope):
+        match subnode:
+            case ast.Expr(
+                value=ast.Call(
+                    func=ast.Attribute(
+                        value=ast.Attribute(
+                            value=ast.Name(id="self"),
+                            attr=receiver,
+                        ) as receiver_node,
+                        attr="start" | "stop",
+                    ),
+                    args=[],
+                    keywords=[],
+                )
+            ) if receiver == name:
+                allowed.add(receiver_node)
+            case ast.Call(args=args):
+                for arg in args:
+                    match arg:
+                        case ast.Attribute(
+                            value=ast.Attribute(
+                                value=ast.Name(id="self"),
+                                attr=receiver,
+                            ) as receiver_node,
+                            attr="start" | "stop",
+                        ) if receiver == name:
+                            allowed.add(receiver_node)
+    return all(
+        subnode in allowed
+        for subnode in ast.walk(scope)
+        if isinstance(subnode, ast.Attribute)
+        and isinstance(subnode.value, ast.Name)
+        and subnode.value.id == "self"
+        and subnode.attr == name
+    )
 
 
 def maybe_migrate_call(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1701,6 +1701,349 @@ class TestMigrateContents:
             reports=[(4, 6, "freeze_time usage not migrated")],
         )
 
+    def test_assign_start_stop(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            def test_function():
+                freezer = freeze_time("2023-01-01")
+                freezer.start()
+                freezer.stop()
+            """,
+            """
+            import time_machine
+
+            def test_function():
+                freezer = time_machine.travel("2023-01-01", tick=False)
+                freezer.start()
+                freezer.stop()
+            """,
+        )
+
+    def test_assign_start_stop_module_level(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            freezer = freeze_time("2023-01-01")
+            freezer.start()
+            freezer.stop()
+            """,
+            """
+            import time_machine
+
+            freezer = time_machine.travel("2023-01-01", tick=False)
+            freezer.start()
+            freezer.stop()
+            """,
+        )
+
+    def test_assign_start_stop_attr_call(self):
+        check_transformed(
+            """
+            import freezegun
+
+            def test_function():
+                freezer = freezegun.freeze_time("2023-01-01")
+                freezer.start()
+                freezer.stop()
+            """,
+            """
+            import time_machine
+
+            def test_function():
+                freezer = time_machine.travel("2023-01-01", tick=False)
+                freezer.start()
+                freezer.stop()
+            """,
+        )
+
+    def test_assign_start_stop_tick(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            def test_function():
+                freezer = freeze_time("2023-01-01", tick=True)
+                freezer.start()
+                freezer.stop()
+            """,
+            """
+            import time_machine
+
+            def test_function():
+                freezer = time_machine.travel("2023-01-01", tick=True)
+                freezer.start()
+                freezer.stop()
+            """,
+        )
+
+    def test_assign_stop_reference(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            def test_function():
+                freezer = freeze_time("2023-01-01")
+                freezer.start()
+                atexit.register(freezer.stop)
+            """,
+            """
+            import time_machine
+
+            def test_function():
+                freezer = time_machine.travel("2023-01-01", tick=False)
+                freezer.start()
+                atexit.register(freezer.stop)
+            """,
+        )
+
+    def test_assign_start_arguments_incompatible(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            def test_function():
+                freezer = freeze_time("2023-01-01")
+                freezer.start(1)
+            """,
+            """
+            import time_machine
+
+            def test_function():
+                freezer = freeze_time("2023-01-01")
+                freezer.start(1)
+            """,
+            reports=[(5, 15, "freeze_time usage not migrated")],
+        )
+
+    def test_assign_start_assigned_incompatible(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            def test_function():
+                freezer = freeze_time("2023-01-01")
+                x = freezer.start()
+            """,
+            """
+            import time_machine
+
+            def test_function():
+                freezer = freeze_time("2023-01-01")
+                x = freezer.start()
+            """,
+            reports=[(5, 15, "freeze_time usage not migrated")],
+        )
+
+    def test_assign_move_to_incompatible(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            def test_function():
+                freezer = freeze_time("2023-01-01")
+                freezer.start()
+                freezer.move_to("2023-06-01")
+                freezer.stop()
+            """,
+            """
+            import time_machine
+
+            def test_function():
+                freezer = freeze_time("2023-01-01")
+                freezer.start()
+                freezer.move_to("2023-06-01")
+                freezer.stop()
+            """,
+            reports=[(5, 15, "freeze_time usage not migrated")],
+        )
+
+    def test_assign_reference_incompatible(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            def test_function():
+                freezer = freeze_time("2023-01-01")
+                helper(freezer)
+            """,
+            """
+            import time_machine
+
+            def test_function():
+                freezer = freeze_time("2023-01-01")
+                helper(freezer)
+            """,
+            reports=[(5, 15, "freeze_time usage not migrated")],
+        )
+
+    def test_assign_reassigned_incompatible(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            def test_function():
+                freezer = freeze_time("2023-01-01")
+                freezer.start()
+                freezer = freeze_time("2024-01-01")
+                freezer.stop()
+            """,
+            """
+            import time_machine
+
+            def test_function():
+                freezer = freeze_time("2023-01-01")
+                freezer.start()
+                freezer = freeze_time("2024-01-01")
+                freezer.stop()
+            """,
+            reports=[
+                (5, 15, "freeze_time usage not migrated"),
+                (7, 15, "freeze_time usage not migrated"),
+            ],
+        )
+
+    def test_assign_unmigratable_call(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            def test_function():
+                freezer = freeze_time("2023-01-01", auto_tick_seconds=1)
+                freezer.start()
+                freezer.stop()
+            """,
+            """
+            import time_machine
+
+            def test_function():
+                freezer = freeze_time("2023-01-01", auto_tick_seconds=1)
+                freezer.start()
+                freezer.stop()
+            """,
+            reports=[(5, 15, "freeze_time usage not migrated")],
+        )
+
+    def test_assign_other_call_noop(self):
+        check_noop(
+            """
+            def test_function():
+                freezer = make_freezer("2023-01-01")
+                freezer.start()
+            """,
+        )
+
+    def test_assign_class_body_noop(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            class TestSomething:
+                freezer = freeze_time("2023-01-01")
+            """,
+            """
+            import time_machine
+
+            class TestSomething:
+                freezer = freeze_time("2023-01-01")
+            """,
+            reports=[(5, 15, "freeze_time usage not migrated")],
+        )
+
+    def test_assign_self_attr(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            class TestSomething(TestCase):
+                def setUp(self):
+                    self.freezer = freeze_time("2023-01-01")
+                    self.freezer.start()
+                    self.addCleanup(self.freezer.stop)
+            """,
+            """
+            import time_machine
+
+            class TestSomething(TestCase):
+                def setUp(self):
+                    self.freezer = time_machine.travel("2023-01-01", tick=False)
+                    self.freezer.start()
+                    self.addCleanup(self.freezer.stop)
+            """,
+        )
+
+    def test_assign_self_attr_teardown(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            class TestSomething(TestCase):
+                def setUp(self):
+                    self.freezer = freeze_time("2023-01-01")
+                    self.freezer.start()
+
+                def tearDown(self):
+                    self.freezer.stop()
+            """,
+            """
+            import time_machine
+
+            class TestSomething(TestCase):
+                def setUp(self):
+                    self.freezer = time_machine.travel("2023-01-01", tick=False)
+                    self.freezer.start()
+
+                def tearDown(self):
+                    self.freezer.stop()
+            """,
+        )
+
+    def test_assign_self_attr_incompatible(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            class TestSomething(TestCase):
+                def setUp(self):
+                    self.freezer = freeze_time("2023-01-01")
+                    self.freezer.start()
+
+                def test_function(self):
+                    self.freezer.tick()
+            """,
+            """
+            import time_machine
+
+            class TestSomething(TestCase):
+                def setUp(self):
+                    self.freezer = freeze_time("2023-01-01")
+                    self.freezer.start()
+
+                def test_function(self):
+                    self.freezer.tick()
+            """,
+            reports=[(6, 24, "freeze_time usage not migrated")],
+        )
+
+    def test_assign_self_attr_outside_class(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            def helper(self):
+                self.freezer = freeze_time("2023-01-01")
+            """,
+            """
+            import time_machine
+
+            def helper(self):
+                self.freezer = freeze_time("2023-01-01")
+            """,
+            reports=[(5, 20, "freeze_time usage not migrated")],
+        )
+
     def test_marker(self):
         check_transformed(
             """

--- a/tests/test_cli_fuzz.py
+++ b/tests/test_cli_fuzz.py
@@ -118,6 +118,20 @@ def pytestmark_statements(draw: st.DrawFn) -> str:
 
 
 @st.composite
+def raw_assignment_statements(draw: st.DrawFn) -> str:
+    receiver = draw(st.sampled_from(["freezer", "ft", "self.freezer"]))
+    lines = [f"{receiver} = " + draw(freeze_time_calls())]
+    for method in draw(
+        st.lists(st.sampled_from(["start", "stop", "move_to", "tick"]), max_size=2)
+    ):
+        if draw(st.booleans()):
+            lines.append(draw(calls(f"{receiver}.{method}", method_arglists)))
+        else:
+            lines.append(f"cleanup({receiver}.{method})")
+    return "\n".join(lines)
+
+
+@st.composite
 def method_statements(draw: st.DrawFn) -> str:
     receiver = draw(st.sampled_from(["freezer", "t", "ft", "tick", "other"]))
     kind = draw(st.sampled_from(["call", "call", "call", "attribute", "reference"]))
@@ -167,6 +181,7 @@ def function_defs(draw: st.DrawFn) -> str:
             st.just("pass")
             | st.just("from freezegun import freeze_time, FakeDate")
             | method_statements()
+            | raw_assignment_statements()
             | with_statements(),
             min_size=1,
             max_size=3,
@@ -214,6 +229,7 @@ def modules(draw: st.DrawFn) -> str:
                 | class_defs()
                 | with_statements()
                 | method_statements()
+                | raw_assignment_statements()
                 | pytestmark_statements(),
                 min_size=1,
                 max_size=3,


### PR DESCRIPTION
Migrate `freeze_time()` calls assigned to a variable or `self.` attribute for "raw use" with `start()` and `stop()`, which have the same interface on `travel()` instances.
Plain variables are checked within the enclosing function or module, and `self.` attributes across the enclosing class, covering unittest `setUp()` / `tearDown()` patterns including `self.addCleanup(self.freezer.stop)`.
Other uses of the variable prevent migration, since freezegun's object has methods with no equivalent on `travel()`.
