### PR TITLE
Extend Migration CLI to drop `ignore` arguments

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,8 @@ Unreleased
 * Extend the :ref:`Migration CLI <migration-cli>` to migrate ``freeze_time()`` calls and markers with no destination argument, which freeze at the current time.
   ``None`` is added as the destination, using the new support for ``None`` destinations (above).
 
+* Extend the :ref:`Migration CLI <migration-cli>` to migrate ``freeze_time()`` calls and markers that pass ``ignore``.
+  The argument is dropped, since it works around problems with freezegun’s module patching, which time-machine’s C-level mocking doesn’t have.
 
 * Make the :ref:`Migration CLI <migration-cli>` report freezegun-related usages that it recognizes but cannot migrate, with their positions, like:
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -98,11 +98,12 @@ The changes the tool makes are:
 * ``from freezegun import freeze_time, FakeDate`` -> ``import time_machine`` plus ``from freezegun import FakeDate``, keeping the other imported names.
 
 * In function decorators, class decorators, and context managers: ``freeze_time(...)`` -> ``travel(...)``.
-  This change is applied only when ``freeze_time()`` is called with a single positional argument and only supported keyword arguments: ``tick``, ``tz_offset`` with a literal zero value, and ``real_asyncio``.
+  This change is applied only when ``freeze_time()`` is called with a single positional argument and only supported keyword arguments: ``tick``, ``tz_offset`` with a literal zero value, ``real_asyncio``, and ``ignore``.
   If ``tick`` is passed, it is kept as-is, otherwise it is replaced with ``tick=False`` (matching freezegun’s default behaviour).
   If no positional argument is passed, ``None`` is added as the destination, meaning the current time, matching freezegun’s behaviour of freezing at the current time.
   ``tz_offset=0`` is dropped, since a zero offset has no effect.
   ``real_asyncio`` is dropped, whatever its value, since time-machine does not mock ``time.monotonic()``, so asyncio event loops always see real time.
+  ``ignore`` is dropped, since it works around problems with freezegun’s module patching, which time-machine’s C-level mocking doesn’t have.
 
 * “Raw use” assignments that bind ``freeze_time()`` to a variable for later ``start()`` and ``stop()`` calls: the assigned call is migrated as above, since ``travel()`` instances have the same ``start()`` / ``stop()`` interface.
   This applies to plain variables, like ``freezer = freeze_time(...)``, checked within the enclosing function or module, and to ``self.`` attributes, checked across the enclosing class, so unittest ``setUp()`` / ``tearDown()`` patterns are covered, including cleanup registrations like ``self.addCleanup(self.freezer.stop)``.

--- a/src/time_machine/cli.py
+++ b/src/time_machine/cli.py
@@ -722,6 +722,10 @@ def droppable_kwarg(kw: ast.keyword) -> bool:
             # time-machine does not mock time.monotonic(), so asyncio event
             # loops always see real time, whatever the value.
             return True
+        case "ignore":
+            # time-machine’s C-level mocking does not need workarounds, so
+            # ignores are hopefully unnecessary.
+            return True
         case _:
             return False
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -908,6 +908,60 @@ class TestMigrateContents:
             """,
         )
 
+    def test_function_decorator_ignore(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            @freeze_time("2023-01-01", ignore=["threading"])
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel("2023-01-01", tick=False)
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_function_decorator_ignore_variable(self):
+        check_transformed(
+            """
+            from freezegun import freeze_time
+
+            @freeze_time("2023-01-01", ignore=IGNORED_MODULES, tick=True)
+            def test_function():
+                pass
+            """,
+            """
+            import time_machine
+
+            @time_machine.travel("2023-01-01", tick=True)
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_marker_ignore(self):
+        check_transformed(
+            """
+            import pytest
+
+            @pytest.mark.freeze_time("2023-01-01", ignore=["threading"])
+            def test_function():
+                pass
+            """,
+            """
+            import pytest
+
+            @pytest.mark.time_machine("2023-01-01", tick=False)
+            def test_function():
+                pass
+            """,
+        )
+
     def test_with_tz_offset_zero(self):
         check_transformed(
             """

--- a/tests/test_cli_fuzz.py
+++ b/tests/test_cli_fuzz.py
@@ -47,6 +47,7 @@ freeze_time_arglists = st.sampled_from(
         ('"2023-01-01"', "tz_offset=0", "tick=True"),
         ('"2023-01-01"', "real_asyncio=True"),
         ('"2023-01-01"', "real_asyncio=False"),
+        ('"2023-01-01"', 'ignore=["threading"]'),
     ]
 )
 


### PR DESCRIPTION
Migrate `freeze_time()` calls and `pytest.mark.freeze_time` markers that pass `ignore`, dropping the argument since it works around problems with freezegun's module patching, which time-machine's C-level mocking doesn't have.
