### PR TITLE
Make Migration CLI report files that cannot be parsed

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,6 +32,9 @@ Unreleased
 
   This makes it easier to find and fix the remaining usages manually.
 
+* Make the :ref:`Migration CLI <migration-cli>` report files that cannot be parsed, rather than skipping them silently.
+  This helps notice files using syntax from a newer Python version than the tool is run with.
+
 * Extend the :ref:`Migration CLI <migration-cli>` to migrate “raw use” assignments of ``freeze_time()`` to variables or ``self.`` attributes used with ``start()`` and ``stop()``, covering unittest ``setUp()`` / ``tearDown()`` patterns like ``self.freezer = freeze_time(...)`` with ``self.addCleanup(self.freezer.stop)``.
 
 * Extend the :ref:`Migration CLI <migration-cli>` to migrate imports and uses of freezegun’s ``FrozenDateTimeFactory`` class, often used to annotate the ``freezer`` fixture argument, to time-machine’s newly-documented equivalent, ``time_machine.TimeMachineFixture``.

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -45,6 +45,9 @@ To help with this, the tool reports freezegun-related usages that it recognizes 
 
 These reports are heuristic and may occasionally flag unrelated code that reuses a freezegun-related name, such as a function parameter that shadows an imported ``freeze_time``.
 
+Files that cannot be parsed are also reported, and otherwise skipped.
+Since the tool parses files with the Python version it runs on, run it with a version at least as new as the target project uses.
+
 The tool edits files in place, reporting those that it changes.
 It’s recommended you start from a clean, committed state in your version control system, so you can easily revert any broken changes.
 

--- a/src/time_machine/cli.py
+++ b/src/time_machine/cli.py
@@ -100,8 +100,12 @@ def migrate_contents(contents_text: str) -> tuple[str, list[Report]]:
     """Migrate a single text from freezegun to time-machine."""
     try:
         ast_obj = ast_parse(contents_text)
-    except SyntaxError:
-        return contents_text, []
+    except (SyntaxError, ValueError) as exc:
+        # ValueError comes from e.g. null bytes in the source.
+        lineno = getattr(exc, "lineno", None) or 1
+        col = getattr(exc, "offset", None) or 1
+        msg = getattr(exc, "msg", None) or str(exc)
+        return contents_text, [Report(lineno, col, f"could not parse file: {msg}")]
 
     callbacks, reports = visit(ast_obj)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,9 +85,25 @@ class TestMain:
         assert result == 0
         out, err = capsys.readouterr()
         assert out == ""
-        assert err == ""
+        assert err == f"{path}:1:5: could not parse file: invalid syntax\n"
 
         assert path.read_text() == "def def def\n"
+
+    def test_migrate_null_byte(self, capsys, tmp_path):
+        path = tmp_path / "example.py"
+        path.write_bytes(b"x = 1\x00\n")
+
+        result = main(["migrate", str(path)])
+
+        assert result == 0
+        out, err = capsys.readouterr()
+        assert out == ""
+        assert err == (
+            f"{path}:1:1: could not parse file: "
+            + "source code string cannot contain null bytes\n"
+        )
+
+        assert path.read_bytes() == b"x = 1\x00\n"
 
     def test_migrate_non_utf8(self, capsys, tmp_path):
         path = tmp_path / "example.py"


### PR DESCRIPTION
Previously such files were skipped silently, which was confusing when running the tool with an older Python version than the target files use, such as on files using newer syntax.
Also catch `ValueError` from parsing, which can occur for sources with null bytes.
