### PR TITLE
Make `TimeMachineFixture` always available

### DIFF
--- a/src/time_machine/__init__.py
+++ b/src/time_machine/__init__.py
@@ -443,6 +443,43 @@ class travel:
 
 # pytest plugin
 
+
+class TimeMachineFixture:
+    traveller: travel | None
+    traveller_obj: Traveller | None
+
+    def __init__(self) -> None:
+        self.traveller = None
+        self.traveller_obj = None
+
+    def move_to(
+        self,
+        destination: DestinationType,
+        tick: bool | None = None,
+    ) -> None:
+        if self.traveller is None:
+            if tick is None:
+                tick = True
+            traveller = travel(destination, tick=tick)
+            self.traveller_obj = traveller.start()
+            self.traveller = traveller
+        else:
+            assert self.traveller_obj is not None
+            self.traveller_obj.move_to(destination, tick=tick)
+
+    def shift(self, delta: dt.timedelta | int | float) -> None:
+        if self.traveller is None:
+            raise RuntimeError(
+                "Initialize time_machine with move_to() before using shift()."
+            )
+        assert self.traveller_obj is not None
+        self.traveller_obj.shift(delta=delta)
+
+    def stop(self) -> None:
+        if self.traveller is not None:
+            self.traveller.stop()
+
+
 if HAVE_PYTEST:  # pragma: no branch
 
     def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
@@ -460,41 +497,6 @@ if HAVE_PYTEST:  # pragma: no branch
         config.addinivalue_line(
             "markers", "time_machine(...): set the time with time-machine"
         )
-
-    class TimeMachineFixture:
-        traveller: travel | None
-        traveller_obj: Traveller | None
-
-        def __init__(self) -> None:
-            self.traveller = None
-            self.traveller_obj = None
-
-        def move_to(
-            self,
-            destination: DestinationType,
-            tick: bool | None = None,
-        ) -> None:
-            if self.traveller is None:
-                if tick is None:
-                    tick = True
-                traveller = travel(destination, tick=tick)
-                self.traveller_obj = traveller.start()
-                self.traveller = traveller
-            else:
-                assert self.traveller_obj is not None
-                self.traveller_obj.move_to(destination, tick=tick)
-
-        def shift(self, delta: dt.timedelta | int | float) -> None:
-            if self.traveller is None:
-                raise RuntimeError(
-                    "Initialize time_machine with move_to() before using shift()."
-                )
-            assert self.traveller_obj is not None
-            self.traveller_obj.shift(delta=delta)
-
-        def stop(self) -> None:
-            if self.traveller is not None:
-                self.traveller.stop()
 
     @pytest.fixture(name="time_machine")
     def time_machine_fixture(

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -1933,6 +1933,30 @@ def test_naive_mode_error_string_aware_works():
 # pytest plugin tests
 
 
+def test_fixture_class_available_without_pytest():
+    # TimeMachineFixture should be importable even when pytest is not
+    # installed.
+    code = dedent(
+        """\
+        import sys
+        sys.modules["pytest"] = None  # block import
+        import time_machine
+        assert not time_machine.HAVE_PYTEST
+        assert time_machine.TimeMachineFixture
+        print("ok")
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+
+    assert result.stdout == "ok\n"
+
+
 def test_fixture_unused(time_machine):
     assert time.time() >= LIBRARY_EPOCH
 


### PR DESCRIPTION
Previously, `TimeMachineFixture` was conditionally available based on whether pytest was installed. This causes issues where it is used for type hinting and ty has the following rules enabled:

```toml
[tool.ty.rules]
possibly-missing-attribute = "warn"
possibly-missing-import = "warn"
```

That results in the following errors:

```console
warning[possibly-missing-import]: Member `TimeMachineFixture` of module `time_machine` may be missing
  --> tests/test_import.py:16:30
   |
16 |     from time_machine import TimeMachineFixture
   |                              ^^^^^^^^^^^^^^^^^^

warning[possibly-missing-attribute]: Member `TimeMachineFixture` may be missing on module `time_machine`
   --> tests/test_attribute.py:239:23
    |
239 |         time_machine: time_machine.TimeMachineFixture,
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Happily, `TimeMachineFixture` doesn't actually refer to anything from pytest itself, so it can be made available always. That leaves the following still guarded which make sense as they'll not be used directly by user code:

- `pytest_collection_modifyitems`
- `pytest_configure`
- `time_machine_fixture`