### PR TITLE
Fix class decorator leaking time travel on setUpClass/tearDownClass errors

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Fix the class decorator to stop time travelling when ``tearDownClass()`` raises an exception, or when ``setUpClass()`` raises an exception not deriving from ``Exception``, such as the skip outcome from ``pytest.skip()``.
+  Previously, time remained mocked for the rest of the process in these cases.
+
 3.5.0 (2026-08-25)
 ------------------
 

--- a/src/time_machine/__init__.py
+++ b/src/time_machine/__init__.py
@@ -394,7 +394,9 @@ class travel:
                 self.__enter__()
                 try:
                     orig_setUpClass(cls)
-                except Exception:
+                except BaseException:
+                    # Stop travlling for any BaseException, not just Exception,
+                    # because pytest.skip() works by raising a BaseException
                     self.__exit__(*sys.exc_info())
                     raise
 
@@ -406,8 +408,10 @@ class travel:
 
             @functools.wraps(orig_tearDownClass)
             def tearDownClass(cls: type[TestCase]) -> None:
-                orig_tearDownClass(cls)
-                self.__exit__(None, None, None)
+                try:
+                    orig_tearDownClass(cls)
+                finally:
+                    self.__exit__(*sys.exc_info())
 
             wrapped.tearDownClass = classmethod(  # type: ignore[assignment]
                 tearDownClass

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import time
 import typing
+import unittest
 import uuid
 import warnings
 from contextlib import contextmanager
@@ -958,6 +959,76 @@ class UnitTestClassSetUpClassSkipTests(TestCase):
 
     def test_thats_always_skipped(self):  # pragma: no cover
         pass
+
+
+def test_class_decorator_setUpClass_base_exception():
+    # pytest's skip outcome, for example, does not derive from Exception.
+    class Interrupt(BaseException):
+        pass
+
+    @time_machine.travel(EPOCH)
+    class InterruptTests(TestCase):
+        @classmethod
+        def setUpClass(cls) -> None:
+            raise Interrupt()
+
+        def test_something(self) -> None:  # pragma: no cover
+            pass
+
+    with pytest.raises(Interrupt):
+        InterruptTests.setUpClass()
+
+    assert not time_machine.escape_hatch.is_travelling()
+    assert time.time() >= LIBRARY_EPOCH
+
+
+def test_class_decorator_setUpClass_pytest_skip(testdir):
+    testdir.makepyfile(
+        """
+        import time
+        from unittest import TestCase
+
+        import pytest
+        import time_machine
+
+        @time_machine.travel(0.0)
+        class SkippedTests(TestCase):
+            @classmethod
+            def setUpClass(cls):
+                pytest.skip("Not today")
+
+            def test_never_runs(self):
+                pass
+
+        def test_after():
+            assert not time_machine.escape_hatch.is_travelling()
+            assert time.time() > 10.0
+        """
+    )
+
+    result = testdir.runpytest("-v", "-s", "-p", "no:randomly")
+    result.assert_outcomes(passed=1, skipped=1)
+
+
+def test_class_decorator_tearDownClass_error():
+    @time_machine.travel(EPOCH)
+    class ErrorTests(TestCase):
+        @classmethod
+        def tearDownClass(cls) -> None:
+            raise ValueError("Broken")
+
+        def test_something(self) -> None:
+            assert EPOCH <= time.time() < EPOCH + 10.0
+
+    result = unittest.TestResult()
+    unittest.defaultTestLoader.loadTestsFromTestCase(ErrorTests).run(result)
+
+    assert result.testsRun == 1
+    assert result.failures == []
+    assert len(result.errors) == 1
+    assert "ValueError: Broken" in result.errors[0][1]
+    assert not time_machine.escape_hatch.is_travelling()
+    assert time.time() >= LIBRARY_EPOCH
 
 
 # extract_timestamp_tzname() tests


### PR DESCRIPTION
The wrapped `tearDownClass()` never called `__exit__()` when the original
raised, and the wrapped `setUpClass()` only stopped travelling for
exceptions deriving from Exception. pytest's skip outcome derives from
`BaseException`, so `pytest.skip()` in `setUpClass()` of a decorated `TestCase`
left time mocked for every later test in the process.
