### PR TITLE
Fix `Traveller.move_to()` unmocking the timezone on an unsupported destination

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,9 @@ Unreleased
 * Fix the class decorator to stop time travelling when ``tearDownClass()`` raises an exception, or when ``setUpClass()`` raises an exception not deriving from ``Exception``, such as the skip outcome from ``pytest.skip()``.
   Previously, time remained mocked for the rest of the process in these cases.
 
+* Fix ``Traveller.move_to()`` to keep the current timezone mocked when the given destination is unsupported.
+  Previously, the timezone was restored before the destination was checked, leaving it unmocked whilst still time travelling.
+
 3.5.0 (2026-08-25)
 ------------------
 

--- a/src/time_machine/__init__.py
+++ b/src/time_machine/__init__.py
@@ -259,9 +259,15 @@ class Traveller:
         tick: bool | None = None,
     ) -> None:
         self._stop()
-        self._destination_timestamp_ns, self._destination_tzname = (
-            extract_timestamp_tzname(destination)
-        )
+        try:
+            self._destination_timestamp_ns, self._destination_tzname = (
+                extract_timestamp_tzname(destination)
+            )
+        except BaseException:
+            # Keep travelling to the current destination, including its
+            # timezone, rather than leaving the timezone unmocked.
+            self._start()
+            raise
         self._requested = False
         self._start()
         if tick is not None:

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -1142,6 +1142,71 @@ def test_shift_when_tick():
 # move_to() tests
 
 
+def test_move_to_unsupported_destination_keeps_timezone():
+    orig_tzname = time.tzname
+    dest = EPOCH_DATETIME.replace(tzinfo=ZoneInfo("Africa/Addis_Ababa"))
+
+    with time_machine.travel(dest, tick=False) as traveller:
+        assert time.tzname == ("EAT", "EAT")
+
+        with pytest.raises(TypeError):
+            traveller.move_to(object())  # type: ignore[arg-type]
+
+        assert time.time() == dest.timestamp()
+        assert time.tzname == ("EAT", "EAT")
+
+    assert time.tzname == orig_tzname
+
+
+def test_move_to_naive_mode_error_keeps_timezone():
+    orig_tzname = time.tzname
+    dest = EPOCH_DATETIME.replace(tzinfo=ZoneInfo("Africa/Addis_Ababa"))
+
+    with time_machine.travel(dest, tick=False) as traveller:
+        assert time.tzname == ("EAT", "EAT")
+
+        with (
+            mock.patch.object(time_machine, "naive_mode", time_machine.NaiveMode.ERROR),
+            pytest.raises(RuntimeError),
+        ):
+            traveller.move_to(dt.datetime(1971, 1, 1))
+
+        assert time.time() == dest.timestamp()
+        assert time.tzname == ("EAT", "EAT")
+
+    assert time.tzname == orig_tzname
+
+
+def test_move_to_naive_string_uses_real_local_timezone():
+    # Naive destinations resolve against the machine’s real timezone (UTC for
+    # the test suite), not that of the traveller being moved from. move_to()
+    # therefore has to unmock the timezone before extracting the destination.
+    dest = EPOCH_DATETIME.replace(tzinfo=ZoneInfo("Africa/Addis_Ababa"))
+
+    with time_machine.travel(dest, tick=False) as traveller:
+        assert time.tzname == ("EAT", "EAT")
+
+        traveller.move_to("1971-01-01 00:00:00", tick=False)
+
+        assert time.time() == EPOCH_PLUS_ONE_YEAR
+
+
+def test_move_to_naive_mode_local_uses_real_local_timezone():
+    with (
+        change_local_timezone("America/Chicago"),
+        mock.patch.object(time_machine, "naive_mode", time_machine.NaiveMode.LOCAL),
+    ):
+        expected = dt.datetime(1971, 1, 1).timestamp()
+        dest = EPOCH_DATETIME.replace(tzinfo=ZoneInfo("Africa/Addis_Ababa"))
+
+        with time_machine.travel(dest, tick=False) as traveller:
+            assert time.tzname == ("EAT", "EAT")
+
+            traveller.move_to(dt.datetime(1971, 1, 1), tick=False)
+
+            assert time.time() == expected
+
+
 def test_move_to_datetime():
     with time_machine.travel(EPOCH) as traveller:
         assert time.time() == EPOCH


### PR DESCRIPTION
`move_to()` restored the real timezone before validating the new destination, so a TypeError left the traveller active with the timezone no longer mocked.
Re-apply the current destination's timezone when extracting the new one fails.
