### PR TITLE
Fix pytest fixture stopping a traveller that failed to start

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,8 @@ Unreleased
 * Fix ``Traveller.move_to()`` to keep the current timezone mocked when the given destination is unsupported.
   Previously, the timezone was restored before the destination was checked, leaving it unmocked whilst still time travelling.
 
+* Fix the ``time_machine`` pytest fixture to not try to stop a traveller that failed to start.
+
 3.5.0 (2026-08-25)
 ------------------
 

--- a/src/time_machine/__init__.py
+++ b/src/time_machine/__init__.py
@@ -478,8 +478,9 @@ if HAVE_PYTEST:  # pragma: no branch
             if self.traveller is None:
                 if tick is None:
                     tick = True
-                self.traveller = travel(destination, tick=tick)
-                self.traveller_obj = self.traveller.start()
+                traveller = travel(destination, tick=tick)
+                self.traveller_obj = traveller.start()
+                self.traveller = traveller
             else:
                 assert self.traveller_obj is not None
                 self.traveller_obj.move_to(destination, tick=tick)

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -1937,6 +1937,21 @@ def test_fixture_shift_without_move_to(time_machine):
     )
 
 
+def test_fixture_start_error():
+    fixture = time_machine.TimeMachineFixture()
+    with (
+        mock.patch.object(
+            time_machine.travel, "start", side_effect=ValueError("Broken")
+        ),
+        pytest.raises(ValueError),
+    ):
+        fixture.move_to(EPOCH)
+
+    assert fixture.traveller is None
+    fixture.stop()  # nothing to stop
+    assert not time_machine.escape_hatch.is_travelling()
+
+
 def test_marker_function(testdir):
     testdir.makepyfile(
         """


### PR DESCRIPTION
`TimeMachineFixture.move_to()` recorded the travel object before `start()`
succeeded, so if `start()` raised, the fixture's teardown would pop an
unrelated traveller from the stack, or raise `IndexError`.
