### PR TITLE
Fix mocked `time.strftime()` accepting `None` as its second argument

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,8 @@ Unreleased
 
 * Fix the ``time_machine`` pytest fixture to not try to stop a traveller that failed to start.
 
+* Fix the mocked ``time.strftime()`` to raise ``TypeError`` when passed ``None`` as its second argument, like the unmocked function, rather than treating it as the current time.
+
 3.5.0 (2026-08-25)
 ------------------
 

--- a/src/_time_machine.c
+++ b/src/_time_machine.c
@@ -656,8 +656,11 @@ static PyObject *
 _time_machine_strftime(PyObject *self, PyObject *args)
 {
     Py_ssize_t nargs = PyTuple_GET_SIZE(args);
-    if (nargs < 1 || nargs > 2 || (nargs == 2 && PyTuple_GET_ITEM(args, 1) != Py_None)) {
-        // Pass through, including invalid arguments for their error messages.
+    if (nargs != 1) {
+        // Pass through when a time tuple is given, including invalid
+        // arguments for their error messages. Unlike gmtime() and
+        // localtime(), strftime() does not accept None to mean the current
+        // time, so an explicit None is passed through for its TypeError.
         return original_strftime(self, args);
     }
 

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -427,6 +427,12 @@ def test_time_strftime_invalid_tuple():
         time.strftime("%Y", ("not", "a", "valid", "tuple"))  # type: ignore[arg-type]
 
 
+def test_time_strftime_none():
+    # Unlike gmtime() and localtime(), strftime() does not accept None.
+    with time_machine.travel(EPOCH), pytest.raises(TypeError):
+        time.strftime("%Y", None)  # type: ignore[arg-type]
+
+
 def test_time_time():
     with time_machine.travel(EPOCH):
         first = time.time()


### PR DESCRIPTION
The real `time.strftime()` raises `TypeError` for an explicit `None` time
tuple, but the mocked version treated it as the current time, a holdover
from the old pure-Python wrapper's `t=None` default. Pass an explicit `None`
through to the original function for its error.
