### PR TITLE
Fix Migration CLI leaving string annotations referring to a removed import

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,9 @@ Unreleased
 * Fix the :ref:`Migration CLI <migration-cli>` to keep the rewritten imports on the same line when a freezegun import shares its line with other code, like ``if TYPE_CHECKING: from freezegun import freeze_time, FakeDate``.
   Previously, the remaining ``from freezegun import FakeDate`` was moved to a new line, outside the block.
 
+* Extend the :ref:`Migration CLI <migration-cli>` to migrate uses of ``FrozenDateTimeFactory`` in string annotations, like ``freezer: "FrozenDateTimeFactory"``.
+  Previously, the import was removed whilst such annotations were left referring to it.
+
 3.5.0 (2026-08-25)
 ------------------
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -267,7 +267,7 @@ In functions with an argument named ``freezer``, the argument is renamed to ``ti
 Other uses of ``freezer`` are left unchanged, for your linter to flag.
 ``freeze_time()`` calls within such functions are also left unchanged, because the renamed argument shadows the ``time_machine`` module.
 
-Imports and uses of ``FrozenDateTimeFactory``, freezegun’s class for the ``freezer`` fixture, often used to annotate the fixture argument, are also migrated: uses are rewritten to time-machine’s equivalent, ``TimeMachineFixture``, and ``from time_machine import TimeMachineFixture`` replaces the freezegun import:
+Imports and uses of ``FrozenDateTimeFactory``, freezegun’s class for the ``freezer`` fixture, often used to annotate the fixture argument, are also migrated: uses, including in string annotations, are rewritten to time-machine’s equivalent, ``TimeMachineFixture``, and ``from time_machine import TimeMachineFixture`` replaces the freezegun import:
 
 .. code-block:: diff
 

--- a/src/time_machine/cli.py
+++ b/src/time_machine/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import re
 import sys
 import warnings
 from collections import defaultdict
@@ -375,8 +376,13 @@ def visit(
             if alias.name == FIXTURE_FACTORY:
                 fixture_bound.add(alias.asname or alias.name)
 
-    fixture_uses: dict[str, list[ast.Name]] = {name: [] for name in fixture_bound}
+    fixture_uses: dict[str, list[ast.Name | ast.Constant]] = {
+        name: [] for name in fixture_bound
+    }
     fixture_blocked: set[str] = set()
+    # String annotations that mention a bound name without being exactly it,
+    # like "FrozenDateTimeFactory | None", which cannot be rewritten.
+    fixture_string_blockers: list[tuple[str, ast.Constant]] = []
     if fixture_bound:
         fixture_blocked = fixture_rebindings(tree, fixture_bound)
         for node in ast.walk(tree):
@@ -393,6 +399,16 @@ def visit(
                     for subnode in ast.walk(node)
                     if isinstance(subnode, ast.Name) and subnode.id in fixture_bound
                 )
+        for constant in annotation_strings(tree):
+            string_value = constant.value
+            assert isinstance(string_value, str)
+            if string_value in fixture_bound:
+                fixture_uses[string_value].append(constant)
+            else:
+                for name in fixture_bound:
+                    if re.search(rf"\b{re.escape(name)}\b", string_value):
+                        fixture_blocked.add(name)
+                        fixture_string_blockers.append((name, constant))
 
     fixture_migratable: set[str] = set()
     fixture_used: set[str] = set()
@@ -425,9 +441,18 @@ def visit(
             for name in fixture_used:
                 fixture_migratable.add(name)
                 for use in fixture_uses[name]:
-                    ret[ast_start_offset(use)].append(
-                        partial(replace_name, src="TimeMachineFixture")
-                    )
+                    if isinstance(use, ast.Name):
+                        ret[ast_start_offset(use)].append(
+                            partial(replace_name, src="TimeMachineFixture")
+                        )
+                    else:
+                        ret[ast_start_offset(use)].append(
+                            partial(
+                                replace_string_constant,
+                                node=use,
+                                value="TimeMachineFixture",
+                            )
+                        )
 
     for import_node in freezegun_from_imports:
         has_freeze_time = any(
@@ -526,9 +551,51 @@ def visit(
                         "pytest.mark.freeze_time usage not migrated",
                     )
                 )
+    for name in unmigrated_fixture_names:
+        unmigrated_strings = [
+            *(use for use in fixture_uses[name] if isinstance(use, ast.Constant)),
+            *(
+                constant
+                for blocker_name, constant in fixture_string_blockers
+                if blocker_name == name
+            ),
+        ]
+        for constant in unmigrated_strings:
+            reports.append(
+                Report(
+                    constant.lineno,
+                    constant.col_offset + 1,
+                    f"{name} usage not migrated",
+                )
+            )
     reports.sort()
 
     return ret, reports
+
+
+def annotation_strings(tree: ast.Module) -> Generator[ast.Constant, None, None]:
+    """
+    Yield the string constants within annotations, which may name types that
+    are not defined until runtime, like ``"FrozenDateTimeFactory"`` or
+    ``Optional["FrozenDateTimeFactory"]``.
+    """
+    for node in ast.walk(tree):
+        annotations: list[ast.expr | None]
+        match node:
+            case ast.FunctionDef() | ast.AsyncFunctionDef():
+                annotations = [node.returns]
+            case ast.arg():
+                annotations = [node.annotation]
+            case ast.AnnAssign():
+                annotations = [node.annotation]
+            case _:
+                continue
+        for annotation in annotations:
+            if annotation is None:
+                continue
+            for subnode in ast.walk(annotation):
+                if isinstance(subnode, ast.Constant) and isinstance(subnode.value, str):
+                    yield subnode
 
 
 def find_freezer_function(
@@ -1120,6 +1187,23 @@ def containing_block(tree: ast.Module, stmt: ast.stmt) -> list[ast.stmt]:
 
 def replace_name(tokens: list[Token], i: int, *, src: str) -> None:
     tokens[i] = Token(name=CODE, src=src)
+
+
+def replace_string_constant(
+    tokens: list[Token], i: int, *, node: ast.Constant, value: str
+) -> None:
+    """
+    Replace the given string constant with one of the given value, keeping the
+    quote style of its first token.
+    """
+    j = find_last_token(tokens, i, node=node)
+    src: str = tokens[i].src
+    # Skip any prefix, like the `r` in r"...".
+    quote_start = next(index for index, char in enumerate(src) if char in "\"'")
+    quote = src[quote_start]
+    if src.startswith(quote * 3, quote_start):
+        quote *= 3
+    tokens[i : j + 1] = [Token(name="STRING", src=f"{quote}{value}{quote}")]
 
 
 def switch_to_travel(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -457,6 +457,125 @@ class TestMigrateContents:
             """,
         )
 
+    def test_fixture_factory_string_annotations(self):
+        check_transformed(
+            """
+            from freezegun.api import FrozenDateTimeFactory
+
+            def test_function(freezer: "FrozenDateTimeFactory") -> 'FrozenDateTimeFactory':
+                fixture: "FrozenDateTimeFactory" = None
+                return fixture
+            """,
+            """
+            from time_machine import TimeMachineFixture
+
+            def test_function(time_machine: "TimeMachineFixture") -> 'TimeMachineFixture':
+                fixture: "TimeMachineFixture" = None
+                return fixture
+            """,
+        )
+
+    def test_fixture_factory_string_annotation_aliased(self):
+        check_transformed(
+            """
+            from freezegun.api import FrozenDateTimeFactory as FDF
+
+            def test_function(freezer: "FDF"):
+                pass
+            """,
+            """
+            from time_machine import TimeMachineFixture
+
+            def test_function(time_machine: "TimeMachineFixture"):
+                pass
+            """,
+        )
+
+    def test_fixture_factory_string_annotation_nested(self):
+        check_transformed(
+            """
+            from typing import Optional
+            from freezegun.api import FrozenDateTimeFactory
+
+            def test_function(freezer: Optional["FrozenDateTimeFactory"] = None):
+                pass
+            """,
+            """
+            from typing import Optional
+            from time_machine import TimeMachineFixture
+
+            def test_function(time_machine: Optional["TimeMachineFixture"] = None):
+                pass
+            """,
+        )
+
+    def test_fixture_factory_string_annotation_quote_styles(self):
+        check_transformed(
+            '''
+            from freezegun.api import FrozenDateTimeFactory
+
+            a: r"FrozenDateTimeFactory" = None
+            b: """FrozenDateTimeFactory""" = None
+            c: "Frozen" "DateTimeFactory" = None
+            ''',
+            '''
+            from time_machine import TimeMachineFixture
+
+            a: "TimeMachineFixture" = None
+            b: """TimeMachineFixture""" = None
+            c: "TimeMachineFixture" = None
+            ''',
+        )
+
+    def test_fixture_factory_string_annotation_containing_kept(self):
+        # The import cannot be removed whilst the annotation refers to it.
+        check_transformed(
+            """
+            from freezegun.api import FrozenDateTimeFactory
+
+            def test_function(freezer: "FrozenDateTimeFactory | None"):
+                fixture: "FrozenDateTimeFactory" = None
+            """,
+            """
+            from freezegun.api import FrozenDateTimeFactory
+
+            def test_function(time_machine: "FrozenDateTimeFactory | None"):
+                fixture: "FrozenDateTimeFactory" = None
+            """,
+            reports=[
+                (4, 28, "FrozenDateTimeFactory usage not migrated"),
+                (5, 14, "FrozenDateTimeFactory usage not migrated"),
+            ],
+        )
+
+    def test_fixture_factory_string_annotation_non_annotation_string_ignored(self):
+        check_transformed(
+            """
+            from freezegun.api import FrozenDateTimeFactory
+
+            def test_function(freezer: FrozenDateTimeFactory):
+                '''Uses FrozenDateTimeFactory.'''
+                name: "str" = "FrozenDateTimeFactory"
+            """,
+            """
+            from time_machine import TimeMachineFixture
+
+            def test_function(time_machine: TimeMachineFixture):
+                '''Uses FrozenDateTimeFactory.'''
+                name: "str" = "FrozenDateTimeFactory"
+            """,
+        )
+
+    def test_fixture_factory_string_annotation_function_local_kept(self):
+        check_noop(
+            """
+            def test_function():
+                from freezegun.api import FrozenDateTimeFactory
+                fixture: "FrozenDateTimeFactory" = None
+            """,
+            reports=[(4, 14, "FrozenDateTimeFactory usage not migrated")],
+        )
+
     def test_fixture_factory_with_freeze_time_import(self):
         check_transformed(
             """


### PR DESCRIPTION
With `freezer: "FrozenDateTimeFactory"`, the freezegun import was removed
as unused whilst the quoted annotation still referred to it. Rewrite
string annotations that exactly name `FrozenDateTimeFactory` to
`TimeMachineFixture`, keeping the quote style, and keep the import, with
a report, when an annotation only contains the name, like
`"FrozenDateTimeFactory | None"`.
