### PR TITLE
Fix Migration CLI producing a duplicate argument when renaming `freezer`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,8 @@ Unreleased
 * Extend the :ref:`Migration CLI <migration-cli>` to migrate uses of ``FrozenDateTimeFactory`` in string annotations, like ``freezer: "FrozenDateTimeFactory"``.
   Previously, the import was removed whilst such annotations were left referring to it.
 
+* Fix the :ref:`Migration CLI <migration-cli>` to not rename a ``freezer`` argument when the function already has a ``time_machine`` argument, which produced invalid syntax.
+
 3.5.0 (2026-08-25)
 ------------------
 

--- a/src/time_machine/cli.py
+++ b/src/time_machine/cli.py
@@ -265,7 +265,11 @@ def visit(
                     for arg in (*node.args.args, *node.args.kwonlyargs)
                     if arg.arg == "freezer"
                 ]
-                if freezer_args:
+                if freezer_args and not any(
+                    arg.arg == "time_machine" for arg in all_arguments(node)
+                ):
+                    # Renaming freezer to time_machine would duplicate an
+                    # existing argument, so leave such functions alone.
                     for arg in freezer_args:
                         ret[ast_start_offset(arg)].append(replace_freezer)
                     freezer_functions.append(
@@ -571,6 +575,22 @@ def visit(
     reports.sort()
 
     return ret, reports
+
+
+def all_arguments(node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[ast.arg]:
+    """
+    Return all the arguments of the given function definition.
+    """
+    arguments = [
+        *node.args.posonlyargs,
+        *node.args.args,
+        *node.args.kwonlyargs,
+    ]
+    if node.args.vararg is not None:
+        arguments.append(node.args.vararg)
+    if node.args.kwarg is not None:
+        arguments.append(node.args.kwarg)
+    return arguments
 
 
 def annotation_strings(tree: ast.Module) -> Generator[ast.Constant, None, None]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3004,6 +3004,36 @@ class TestMigrateContents:
             """,
         )
 
+    def test_freezer_fixture_existing_time_machine_argument(self):
+        # Renaming would duplicate the argument, giving invalid syntax.
+        check_noop(
+            """
+            def test_function(freezer, time_machine):
+                freezer.move_to("2023-01-01")
+                freezer.tick()
+            """,
+        )
+
+    def test_freezer_fixture_existing_time_machine_vararg(self):
+        # Renaming would duplicate the argument, giving invalid syntax.
+        check_noop(
+            """
+            def test_function(freezer, *time_machine):
+                freezer.move_to("2023-01-01")
+                freezer.tick()
+            """,
+        )
+
+    def test_freezer_fixture_existing_time_machine_kwarg(self):
+        # Renaming would duplicate the argument, giving invalid syntax.
+        check_noop(
+            """
+            def test_function(freezer, **time_machine):
+                freezer.move_to("2023-01-01")
+                freezer.tick()
+            """,
+        )
+
     def test_freezer_fixture_keyword_only(self):
         check_transformed(
             """


### PR DESCRIPTION
Renaming a `freezer` argument to `time_machine` in a function that
already had a `time_machine` argument produced invalid syntax. Leave such
functions unchanged.
