### PR TITLE
Extend Migration CLI fuzz grammar

### DIFF
--- a/src/time_machine/cli.py
+++ b/src/time_machine/cli.py
@@ -268,8 +268,6 @@ def visit(
                 if freezer_args and not any(
                     arg.arg == "time_machine" for arg in all_arguments(node)
                 ):
-                    # Renaming freezer to time_machine would duplicate an
-                    # existing argument, so leave such functions alone.
                     for arg in freezer_args:
                         ret[ast_start_offset(arg)].append(replace_freezer)
                     freezer_functions.append(

--- a/tests/test_cli_fuzz.py
+++ b/tests/test_cli_fuzz.py
@@ -181,6 +181,8 @@ def function_defs(draw: st.DrawFn) -> str:
                 "freezer, other",
                 "other",
                 "freezer: FrozenDateTimeFactory",
+                'freezer: "FrozenDateTimeFactory"',
+                "freezer, time_machine",
             ]
         )
     )


### PR DESCRIPTION
Fuzz the last two fixes with string annotations and `time_machine` arguments.
