### PR TITLE
Fix Migration CLI reporting positions in the original file after rewriting

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,9 @@ Unreleased
 
 * Fix the :ref:`Migration CLI <migration-cli>` to not rename a ``freezer`` argument when the function already has a ``time_machine`` argument, which produced invalid syntax.
 
+* Fix the :ref:`Migration CLI <migration-cli>` to report positions in the rewritten file, rather than the original.
+  Previously, positions could be off when rewrites earlier in the file changed the number of lines, or the length of the same line.
+
 3.5.0 (2026-08-25)
 ------------------
 

--- a/src/time_machine/cli.py
+++ b/src/time_machine/cli.py
@@ -5,9 +5,11 @@ import ast
 import re
 import sys
 import warnings
+from bisect import bisect_right
 from collections import defaultdict
 from collections.abc import Callable, Generator, Mapping, MutableMapping, Sequence
 from functools import partial
+from operator import itemgetter
 from typing import NamedTuple
 
 from tokenize_rt import (
@@ -127,7 +129,57 @@ def migrate_contents(contents_text: str) -> tuple[str, list[Report]]:
 
     # no types for tokenize-rt
     new_text: str = tokens_to_src(tokens)
-    return new_text, reports
+    return new_text, relocate_reports(reports, tokens)
+
+
+def relocate_reports(reports: list[Report], tokens: list[Token]) -> list[Report]:
+    """
+    Move the given reports, positioned in the original source, to their
+    positions in the rewritten source, as the user sees them alongside the
+    rewritten file.
+    """
+    # Map the original positions of the surviving tokens to their new ones,
+    # per original line, in order.
+    positions: defaultdict[int, list[tuple[int, int, int]]] = defaultdict(list)
+    lineno = 1
+    utf8_byte_offset = 0
+    for token in tokens:
+        if token.line is not None:
+            positions[token.line].append(
+                (token.utf8_byte_offset, lineno, utf8_byte_offset)
+            )
+        src: str = token.src
+        newlines = src.count("\n")
+        if newlines:
+            lineno += newlines
+            utf8_byte_offset = len(src.rpartition("\n")[2].encode())
+        else:
+            utf8_byte_offset += len(src.encode())
+
+    relocated = []
+    for report in reports:
+        col_offset = report.col - 1
+        # Find the token containing the reported position. Reported usages
+        # are not rewritten, so their tokens survive with the same source,
+        # but on Python < 3.12 names within f-strings have no tokens of
+        # their own, so the position may lie within a string token.
+        line_positions = positions[report.lineno]
+        index = bisect_right(line_positions, col_offset, key=itemgetter(0)) - 1
+        if index < 0:  # pragma: no cover
+            # No token starts on the line, which can only happen within a
+            # multi-line string. Leave the report at its original position.
+            relocated.append(report)
+            continue
+        token_offset, new_lineno, new_offset = line_positions[index]
+        relocated.append(
+            Report(
+                new_lineno,
+                new_offset + (col_offset - token_offset) + 1,
+                report.message,
+            )
+        )
+    relocated.sort()
+    return relocated
 
 
 def ast_parse(contents_text: str) -> ast.Module:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -173,6 +173,33 @@ class TestMain:
             "import time_machine\n@freeze_time\ndef test_function():\n    pass\n"
         )
 
+    def test_migrate_reports_positioned_in_rewritten_file(self, capsys, tmp_path):
+        path = tmp_path / "example.py"
+        path.write_text(
+            "from freezegun import freeze_time, FakeDate\n"
+            "@freeze_time\n"
+            "def test_function():\n"
+            "    pass\n"
+        )
+
+        result = main(["migrate", str(path)])
+
+        assert result == 1
+        out, err = capsys.readouterr()
+        assert out == ""
+        # The rewritten import spans two lines, moving the usage down one.
+        assert err == (
+            f"Rewriting {path}\n" + f"{path}:3:2: freeze_time usage not migrated\n"
+        )
+
+        assert path.read_text() == (
+            "import time_machine\n"
+            "from freezegun import FakeDate\n"
+            "@freeze_time\n"
+            "def test_function():\n"
+            "    pass\n"
+        )
+
 
 def check_noop(
     given: str,
@@ -543,7 +570,7 @@ class TestMigrateContents:
                 fixture: "FrozenDateTimeFactory" = None
             """,
             reports=[
-                (4, 28, "FrozenDateTimeFactory usage not migrated"),
+                (4, 33, "FrozenDateTimeFactory usage not migrated"),
                 (5, 14, "FrozenDateTimeFactory usage not migrated"),
             ],
         )
@@ -646,7 +673,8 @@ class TestMigrateContents:
             def test_function():
                 pass
             """,
-            reports=[(4, 1, "FrozenDateTimeFactory usage not migrated")],
+            # Positioned in the migrated text, after the import expanded.
+            reports=[(5, 1, "FrozenDateTimeFactory usage not migrated")],
         )
 
     def test_fixture_factory_fstring_kept(self):
@@ -3086,6 +3114,34 @@ class TestMigrateContents:
             with time_machine.travel("2023-01-01", tick=False) as tick:
                 (tick).shift(1)
             """,
+        )
+
+    def test_reports_positioned_after_rewrite_on_same_line(self):
+        check_transformed(
+            """
+            pytestmark = [pytest.mark.freeze_time(), pytest.mark.freeze_time]
+            """,
+            """
+            pytestmark = [pytest.mark.time_machine(None, tick=False), pytest.mark.freeze_time]
+            """,
+            reports=[(2, 59, "pytest.mark.freeze_time usage not migrated")],
+        )
+
+    def test_reports_positioned_after_rewrite_within_fstring(self):
+        # On Python < 3.12, names within f-strings have no tokens of their own.
+        check_transformed(
+            """
+            from freezegun import freeze_time, FrozenDateTimeFactory
+
+            print(f"{FrozenDateTimeFactory} here")
+            """,
+            """
+            import time_machine
+            from freezegun import FrozenDateTimeFactory
+
+            print(f"{FrozenDateTimeFactory} here")
+            """,
+            reports=[(5, 10, "FrozenDateTimeFactory usage not migrated")],
         )
 
     def test_freezer_fixture_other_method(self):


### PR DESCRIPTION
Reports of unmigrated usages are printed after the file is rewritten,
but their positions came from the original source. Rewrites earlier in
the file that add or remove lines, or change the length of the same line,
left them pointing at the wrong place. Relocate each report to the
position of its token in the rewritten text.
