### PR TITLE
Fix Migration CLI reporting migrated calls with a parenthesized module

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,8 @@ Unreleased
 * Fix the :ref:`Migration CLI <migration-cli>` to report positions in the rewritten file, rather than the original.
   Previously, positions could be off when rewrites earlier in the file changed the number of lines, or the length of the same line.
 
+* Fix the :ref:`Migration CLI <migration-cli>` to not report a ``freezegun`` usage for migrated calls with a parenthesized module name, like ``(freezegun).freeze_time(...)``.
+
 3.5.0 (2026-08-25)
 ------------------
 

--- a/src/time_machine/cli.py
+++ b/src/time_machine/cli.py
@@ -575,6 +575,16 @@ def visit(
 
     unmigrated_fixture_names = fixture_bound - fixture_migratable
 
+    # Names within migrated attribute accesses, which may start after them
+    # when parenthesized, like `(freezegun).freeze_time`.
+    migrated_attribute_names = {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and ast_start_offset(node) in ret
+    }
+
     reports = []
     for node in ast.walk(tree):
         match node:
@@ -583,7 +593,10 @@ def visit(
                 or name in freezegun_module_names
                 or name in report_module_names
                 or name in unmigrated_fixture_names
-            ) and ast_start_offset(node) not in ret:
+            ) and (
+                ast_start_offset(node) not in ret
+                and node not in migrated_attribute_names
+            ):
                 reports.append(
                     Report(
                         node.lineno,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3116,6 +3116,22 @@ class TestMigrateContents:
             """,
         )
 
+    def test_with_attr_parenthesized_module(self):
+        check_transformed(
+            """
+            import freezegun
+
+            with (freezegun).freeze_time("2023-01-01"):
+                pass
+            """,
+            """
+            import time_machine
+
+            with time_machine.travel("2023-01-01", tick=False):
+                pass
+            """,
+        )
+
     def test_reports_positioned_after_rewrite_on_same_line(self):
         check_transformed(
             """


### PR DESCRIPTION
For `(freezegun).freeze_time(...)`, the call was migrated but the
`freezegun` name was still reported as unmigrated, since it starts one
column after the attribute access that the migration is keyed on.
