### PR TITLE
Fix Migration CLI emptying a block by removing several unused imports

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,6 +28,8 @@ Unreleased
 
 * Fix the :ref:`Migration CLI <migration-cli>` to not report a ``freezegun`` usage for migrated calls with a parenthesized module name, like ``(freezegun).freeze_time(...)``.
 
+* Fix the :ref:`Migration CLI <migration-cli>` to leave a ``pass`` statement when removing every unused ``FrozenDateTimeFactory`` import in a block, rather than producing invalid syntax.
+
 3.5.0 (2026-08-25)
 ------------------
 

--- a/src/time_machine/cli.py
+++ b/src/time_machine/cli.py
@@ -508,6 +508,7 @@ def visit(
                             )
                         )
 
+    removed_imports: list[ast.ImportFrom] = []
     for import_node in freezegun_from_imports:
         has_freeze_time = any(
             alias.name == "freeze_time" for alias in import_node.names
@@ -537,13 +538,19 @@ def visit(
             ret[ast_start_offset(import_node)].append(
                 partial(replace_import_from, node=import_node, new_stmts=new_stmts)
             )
-        elif len(containing_block(tree, import_node)) >= 2:
+        else:
+            removed_imports.append(import_node)
+
+    for import_node in removed_imports:
+        block = containing_block(tree, import_node)
+        remaining = [stmt for stmt in block if stmt not in removed_imports]
+        if remaining or block[-1] is not import_node:
             ret[ast_start_offset(import_node)].append(
                 partial(remove_statement, node=import_node)
             )
         else:
-            # The only statement in its block, so removing it would leave
-            # invalid syntax.
+            # Removing every statement in the block would leave invalid
+            # syntax, so replace the last with `pass`.
             ret[ast_start_offset(import_node)].append(
                 partial(replace_import_from, node=import_node, new_stmts=["pass"])
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -827,6 +827,30 @@ class TestMigrateContents:
             """,
         )
 
+    def test_fixture_factory_unused_all_statements_in_block(self):
+        check_transformed(
+            """
+            def test_function():
+                from freezegun.api import FrozenDateTimeFactory
+                from freezegun.api import FrozenDateTimeFactory
+            """,
+            """
+            def test_function():
+                pass
+            """,
+        )
+
+    def test_fixture_factory_unused_all_statements_in_module(self):
+        check_transformed(
+            """
+            from freezegun.api import FrozenDateTimeFactory
+            from freezegun import FrozenDateTimeFactory as FDF
+            """,
+            """
+            pass
+            """,
+        )
+
     def test_import_from_freezegun(self):
         check_transformed(
             "from freezegun import freeze_time",


### PR DESCRIPTION
Each unused `FrozenDateTimeFactory` import was removed when its block had
at least two statements, without accounting for the other statements
also being removed imports, leaving an empty block. Replace the last
removed import in such a block with `pass`.
