### PR TITLE
Fix mocked `datetime.today()` rounding microseconds for far-future dates

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ----------
 
+* Fix the mocked ``datetime.date.today()`` and ``datetime.datetime.today()`` to be exact for all supported dates, like ``datetime.datetime.now()``.
+  Previously, they went through a floating-point timestamp, which could round the microseconds, or even the whole day, for dates far in the future.
+
 * Fix the class decorator to stop time travelling when ``tearDownClass()`` raises an exception, or when ``setUpClass()`` raises an exception not deriving from ``Exception``, such as the skip outcome from ``pytest.skip()``.
   Previously, time remained mocked for the rest of the process in these cases.
 

--- a/src/_time_machine.c
+++ b/src/_time_machine.c
@@ -412,8 +412,8 @@ Return what datetime.datetime.utcnow() would, after patching.");
 
 /* datetime.date.today() and datetime.datetime.today()
  * Note: datetime.datetime doesn't define its own today(), it inherits from date.
- * So we patch date.today() with a wrapper that calls cls.fromtimestamp(), which
- * returns the right type for date, datetime, and subclasses of either.
+ * So we patch date.today() with a single wrapper that handles cls being date,
+ * datetime, or a subclass of either.
  */
 
 static PyObject *
@@ -425,7 +425,18 @@ _time_machine_today(PyObject *cls, PyObject *args)
         return original_date_today(cls, args);
     }
 
-    PyObject *timestamp = _time_machine_traveller_time(traveller, state);
+    // cls is always a type, since today() is a classmethod.
+    if (PyType_IsSubtype((PyTypeObject *)cls, (PyTypeObject *)state->datetime_class)) {
+        // datetime.today() is datetime.now() without a timezone. Build it
+        // exactly, since a float timestamp can round the microseconds.
+        PyObject *result = _time_machine_traveller_datetime(cls, Py_None, traveller, state);
+        Py_DECREF(traveller);
+        return result;
+    }
+
+    // date.fromtimestamp() ignores the fractional part of the timestamp, so
+    // pass whole seconds, which are exact.
+    PyObject *timestamp = _time_machine_traveller_seconds(traveller, state);
     Py_DECREF(traveller);
     if (timestamp == NULL) {
         return NULL;

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -227,6 +227,35 @@ def test_date_today():
     assert dt.datetime.today() >= LIBRARY_EPOCH_DATETIME
 
 
+def test_datetime_today_exact_far_future():
+    # A float timestamp this large cannot represent every microsecond.
+    destination = dt.datetime(2243, 1, 1, 0, 0, 0, 1, tzinfo=dt.timezone.utc)
+    with time_machine.travel(destination, tick=False):
+        assert dt.datetime.today() == destination.replace(tzinfo=None)
+        assert dt.date.today() == destination.date()
+
+
+def test_datetime_today_subclass_exact_far_future():
+    class DatetimeSubclass(dt.datetime):
+        pass
+
+    destination = dt.datetime(2243, 1, 1, 0, 0, 0, 1, tzinfo=dt.timezone.utc)
+    with time_machine.travel(destination, tick=False):
+        today = DatetimeSubclass.today()
+    assert isinstance(today, DatetimeSubclass)
+    assert today == destination.replace(tzinfo=None)
+
+
+def test_date_today_exact_far_future():
+    # A float timestamp this large rounds up past midnight, which would move
+    # the date on by a whole day.
+    destination = dt.datetime(3000, 1, 1, tzinfo=dt.timezone.utc) - dt.timedelta(
+        microseconds=1
+    )
+    with time_machine.travel(destination, tick=False):
+        assert dt.date.today() == dt.date(2999, 12, 31)
+
+
 # time module
 
 


### PR DESCRIPTION
The patched `date.today()` built its result from a float timestamp, so
for `datetime` subclasses the microseconds could round wrongly once the
timestamp grew large enough, from around the year 2100. Build datetimes
exactly, as the patched `datetime.now()` does, and pass whole seconds for
dates, which ignore the fraction anyway.
