### PR TITLE
Only use -mno-omit-leaf-frame-pointer where supported

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,11 @@ Changelog
 Unreleased
 ----------
 
+* Only pass the compiler option ``-mno-omit-leaf-frame-pointer`` when the compiler supports it, checked with a tiny probe program.
+  The option is unsupported outside of x86 and ARM64, so this fixes building from source on other architectures, like PowerPC, which failed since the option was added in version 3.3.0.
+
+  Thanks to Colin Watson for pointing this out and linking to the workaround in `Debian Bug #1146407 <https://bugs.debian.org/1146407>`__.
+
 * Fix the mocked ``datetime.date.today()`` and ``datetime.datetime.today()`` to be exact for all supported dates, like ``datetime.datetime.now()``.
   Previously, they went through a floating-point timestamp, which could round the microseconds, or even the whole day, for dates far in the future.
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import os
 import sys
+import tempfile
 
 from setuptools import Extension, setup
+from setuptools.command.build_ext import build_ext
+from setuptools.errors import CompileError
 
 if hasattr(sys, "pypy_version_info"):
     raise RuntimeError(
@@ -10,20 +14,41 @@ if hasattr(sys, "pypy_version_info"):
         "https://github.com/adamchainz/time-machine/issues/305"
     )
 
-extra_compile_args = []
-if sys.platform != "win32":
-    extra_compile_args += [
-        "-fno-omit-frame-pointer",
-        "-mno-omit-leaf-frame-pointer",
-    ]
+
+class BuildExt(build_ext):  # type: ignore[misc]
+    def build_extensions(self) -> None:
+        if self.compiler.compiler_type != "msvc":
+            flags = ["-fno-omit-frame-pointer"]
+            # Unsupported on some architectures, like PowerPC:
+            if self._has_flag("-mno-omit-leaf-frame-pointer"):
+                flags.append("-mno-omit-leaf-frame-pointer")
+            for extension in self.extensions:
+                extension.extra_compile_args.extend(flags)
+        super().build_extensions()
+
+    def _has_flag(self, flag: str) -> bool:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = os.path.join(tmpdir, "probe.c")
+            with open(source, "w") as fp:
+                fp.write("int main(void) { return 0; }\n")
+            try:
+                self.compiler.compile(
+                    [source],
+                    output_dir=tmpdir,
+                    # -Werror since Clang only warns on unknown -m… flags:
+                    extra_postargs=[flag, "-Werror"],
+                )
+            except CompileError:
+                return False
+        return True
 
 
 setup(
+    cmdclass={"build_ext": BuildExt},
     ext_modules=[
         Extension(
             name="_time_machine",
             sources=["src/_time_machine.c"],
-            extra_compile_args=extra_compile_args,
         )
-    ]
+    ],
 )


### PR DESCRIPTION
Use a tiny probe program to check if the compiler supports the -mno-omit-leaf-frame-pointer option, and only pass it when it does.

The option is unsupported outside of x86 and ARM64, so this fixes building from source on other architectures, like PowerPC, which failed since it was added in #627.

Thanks to @cjwatson for reporting: https://github.com/adamchainz/time-machine/pull/627#issuecomment-5512795406
