### PR TITLE
Adapt tests for platforms with 32-bit time_t

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,3 +6,16 @@ import time
 # Isolate tests from the host machine’s timezone
 os.environ["TZ"] = "UTC"
 time.tzset()
+
+
+def _have_64_bit_time_t() -> bool:
+    # Probe with a post-2038 timestamp: platforms with 32-bit time_t raise
+    # OverflowError (or OSError) when converting it.
+    try:
+        time.gmtime(2**31)
+    except (OverflowError, OSError):  # pragma: no cover
+        return False
+    return True
+
+
+HAVE_64_BIT_TIME_T = _have_64_bit_time_t()

--- a/tests/test_fuzz.py
+++ b/tests/test_fuzz.py
@@ -24,6 +24,7 @@ from hypothesis import strategies as st
 from hypothesis.stateful import RuleBasedStateMachine, invariant, precondition, rule
 
 import time_machine
+from tests.conftest import HAVE_64_BIT_TIME_T
 
 NANOSECONDS_PER_SECOND = time_machine.NANOSECONDS_PER_SECOND
 EPOCH_AWARE = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
@@ -31,7 +32,11 @@ EPOCH_AWARE = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
 # Bounds that keep generated timestamps positive, whatever timezone offset is
 # applied, and well within the range that all supported platforms can convert.
 MIN_DATETIME = dt.datetime(1970, 1, 2)
-MAX_DATETIME = dt.datetime(2500, 1, 1)
+if HAVE_64_BIT_TIME_T:
+    MAX_DATETIME = dt.datetime(2500, 1, 1)
+else:  # pragma: no cover
+    # 32-bit time_t cannot represent timestamps beyond 2038-01-19.
+    MAX_DATETIME = dt.datetime(2038, 1, 1)
 MIN_TIMESTAMP = MIN_DATETIME.replace(tzinfo=dt.timezone.utc).timestamp()
 MAX_TIMESTAMP = MAX_DATETIME.replace(tzinfo=dt.timezone.utc).timestamp()
 

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -21,6 +21,7 @@ import pytest
 from dateutil import tz
 
 import time_machine
+from tests.conftest import HAVE_64_BIT_TIME_T
 
 NANOSECONDS_PER_SECOND = time_machine.NANOSECONDS_PER_SECOND
 EPOCH_DATETIME = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
@@ -41,6 +42,10 @@ py_utcnow_deprecated = pytest.mark.skipif(
 )
 py_utcnow_not_deprecated = pytest.mark.skipif(
     sys.version_info >= (3, 12), reason="utcnow() deprecated on Python 3.12+"
+)
+have_64_bit_time_t = pytest.mark.skipif(
+    not HAVE_64_BIT_TIME_T,
+    reason="Platform has 32-bit time_t, cannot represent distant destinations",
 )
 
 
@@ -139,6 +144,7 @@ def test_datetime_now_subclass():
         assert now.year == 1970
 
 
+@have_64_bit_time_t
 def test_datetime_now_distant_destination_exact():
     # Microsecond precision survives destinations far from the epoch, which a
     # floating-point timestamp could not represent.
@@ -201,6 +207,7 @@ def test_datetime_utcnow_no_tick():
         assert now.microsecond == 0
 
 
+@have_64_bit_time_t
 def test_datetime_utcnow_distant_destination_exact():
     destination = dt.datetime(2500, 1, 1, microsecond=1, tzinfo=dt.timezone.utc)
     with time_machine.travel(destination, tick=False):
@@ -360,6 +367,7 @@ def test_time_gmtime_no_args_no_tick():
         assert local_time.tm_sec == 0
 
 
+@have_64_bit_time_t
 def test_time_gmtime_no_args_distant_destination():
     # The struct fields stay exact for distant destinations, since gmtime()
     # receives whole integer seconds.


### PR DESCRIPTION
Detect 32-bit time_t with a runtime probe and skip distant-destination tests that cannot work there, plus cap the fuzz test bounds before 2038. Prompted by Debian patching out these test failures on i386: https://bugs.debian.org/1146407